### PR TITLE
Remove driver mapping

### DIFF
--- a/build/config.yml
+++ b/build/config.yml
@@ -4,8 +4,4 @@ images:
   csi-attacher:         registry.redhat.io/openshift3/csi-attacher:v3.11
   csi-provisioner:      registry.redhat.io/openshift3/csi-provisioner:v3.11
   driver-registrar:     registry.redhat.io/openshift3/csi-driver-registrar:v3.11
-  ember-csi-driver:
-    rbd:        akrog/ember-csi:master
-    xtremio:    akrog/ember-csi:master
-    lvm:        akrog/ember-csi:master
-
+  ember-csi-driver:     akrog/ember-csi:master

--- a/pkg/controller/embercsi/config.go
+++ b/pkg/controller/embercsi/config.go
@@ -15,17 +15,8 @@ type Config struct {
                 Attacher        string `yaml:"csi-attacher"`
                 Provisioner     string `yaml:"csi-provisioner"`
                 Registrar       string `yaml:"driver-registrar"`
-                Driver          map[string]string `yaml:"ember-csi-driver"`
+                Driver          string `yaml:"ember-csi-driver"`
         } `yaml:"images"`
-}
-
-func (config *Config) getDriverImage( backend string ) string {
-	if len(backend) > 0 && len(config.Images.Driver[backend]) > 0 {
-		return config.Images.Driver[backend]
-	} else {
-		// Return default driver image
-		return "akrog/ember-csi:master"
-	}
 }
 
 func (config *Config) getCluster() string {
@@ -59,13 +50,10 @@ func NewConfig ( configFile *string ) *Config {
 
 // Populate the Config Stuct with some default values and Return it
 func DefaultConfig () *Config {
-	driver := map[string]string {
-		"default":"akrog/ember-csi:master",
-	}
 	Conf.Cluster = "ocp"
 	Conf.Images.Attacher = "registry.redhat.io/openshift3/csi-attacher:v3.11"
 	Conf.Images.Provisioner = "registry.redhat.io/openshift3/csi-provisioner:v3.11"
 	Conf.Images.Registrar = "registry.redhat.io/openshift3/csi-driver-registrar:v3.11"
-	Conf.Images.Driver = driver
+	Conf.Images.Driver = "akrog/ember-csi:master"
 	return Conf
 }

--- a/pkg/controller/embercsi/embercsi_controller.go
+++ b/pkg/controller/embercsi/embercsi_controller.go
@@ -236,8 +236,7 @@ func (r *ReconcileEmberCSI) statefulSetForEmberCSI(ecsi *embercsiv1alpha1.EmberC
 						},
 					},{
 						Name:    "ember-csi-driver",
-						Image:   Conf.getDriverImage(ecsi.Spec.Backend),
-						//Image:   fmt.Sprintf("%s:%s", "akrog/ember-csi", DriverVersion),
+						Image:   Conf.Images.Driver,
 						SecurityContext: &corev1.SecurityContext{
 							Privileged: &trueVar,
 						},
@@ -456,8 +455,7 @@ func (r *ReconcileEmberCSI) daemonSetForEmberCSI(ecsi *embercsiv1alpha1.EmberCSI
 							},
 						},{
 							Name:		"ember-csi-driver",
-							Image:		Conf.getDriverImage(ecsi.Spec.Backend),
-							//Image:		fmt.Sprintf("%s:%s", "akrog/ember-csi", DriverVersion),
+							Image:		Conf.Images.Driver,
 							ImagePullPolicy: corev1.PullAlways,
 							SecurityContext: &corev1.SecurityContext{
 								Privileged: 		  &trueVar,


### PR DESCRIPTION
The driver mapping is kind of static and only works for a subset of
backends.  Defaulting to a single container image allows a more simple
and safe usage.