### PR TITLE
readme: fix typo in ember-csi

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ $ oc create -f deploy/examples/external-ceph-cr.yaml
 ```
 ## Verify that the pods are created and the Storageclass exists
 ```
-$ oc get pods -n enber-csi
+$ oc get pods -n ember-csi
 NAME            READY     STATUS    RESTARTS   AGE
 ember-csi-operator-786769bdc7-dfl4l   1/1       Running   0          11m
 ember-csi-test-controller-0           3/3       Running   0          11m


### PR DESCRIPTION
Fixed a typo in README.md:
s/enber-csi/ember-csi

Change-Id: Iba530a32f022c3820fb4326df8f397a59a27832e
Signed-off-by: Daniel Erez <derez@redhat.com>