### PR TITLE
Build binary in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git/
+build/_output/

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ ember-csi-operator: $(GOLANG_FILES)
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build \
 	-o build/$@ cmd/manager/main.go
 
-build: compile
-	docker build -t $(REPO):$(TAG) -f build/Dockerfile build
+build:
+	docker build -t $(REPO):$(TAG) -f build/Dockerfile .
 
 push:
 	docker push $(REPO):$(TAG)

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,8 +1,20 @@
+FROM openshift/origin-release:golang-1.10
+
+RUN mkdir -p /go/src/github.com/embercsi/ember-csi-operator/
+RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+
+COPY . /go/src/github.com/embercsi/ember-csi-operator/
+WORKDIR /go/src/github.com/embercsi/ember-csi-operator/
+
+RUN make dep
+RUN make compile
+
 FROM centos:7
 
+RUN yum update -y; yum clean all
+
 RUN mkdir /etc/ember-csi-operator && chmod 755 /etc/ember-csi-operator
-ADD config.yml /etc/ember-csi-operator/config.yml
+ADD build/config.yml /etc/ember-csi-operator/config.yml
 USER nobody
 
-ADD ember-csi-operator /usr/local/bin/ember-csi-operator
-
+COPY --from=0 /go/src/github.com/embercsi/ember-csi-operator/build/ember-csi-operator /usr/local/bin/ember-csi-operator

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,7 +11,7 @@ RUN make compile
 
 FROM centos:7
 
-RUN yum update -y; yum clean all
+RUN yum update -y && yum clean all
 
 RUN mkdir /etc/ember-csi-operator && chmod 755 /etc/ember-csi-operator
 ADD build/config.yml /etc/ember-csi-operator/config.yml


### PR DESCRIPTION
This will resolve issue #9.

Note: multi-stage builds are a new feature requiring Docker 17.05 or
higher on the daemon and client.