### PR TITLE
Use public images from quay.io

### DIFF
--- a/build/config.yml
+++ b/build/config.yml
@@ -1,9 +1,9 @@
 ---
 cluster: ocp
 images:
-  csi-attacher:         registry.redhat.io/openshift3/csi-attacher:v3.11
-  csi-provisioner:      registry.redhat.io/openshift3/csi-provisioner:v3.11
-  driver-registrar:     registry.redhat.io/openshift3/csi-driver-registrar:v3.11
+  csi-attacher:         quay.io/k8scsi/csi-attacher:v0.3.0
+  csi-provisioner:      quay.io/k8scsi/csi-provisioner:v0.3.0
+  driver-registrar:     quay.io/k8scsi/driver-registrar:v0.3.0
   ember-csi-driver:
     rbd:        embercsi/ember-csi:master
     xtremio:    embercsi/ember-csi:master


### PR DESCRIPTION
Images from registry.redhat.io are only available with a Red Hat login,
thus using public images from quay.io for upstream releases.