### PR TITLE
Add Dockerfile for non-multistage builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ To build the operator, clone this repo into your GOPATH and run make. NOTE: Plea
 $ mkdir -p ${GOPATH}/src/github.com/embercsi
 $ git clone -b devel https://github.com/embercsi/ember-csi-operator
 $ cd ember-csi-operator
-$ make
+$ make build
+```
+If the used Docker release supports multistage builds, you can enable this by setting the MULTISTAGE_BUILD env var:
+```
+$ MULTISTAGE_BUILD=1 make build
 ```
 
 ## Quick Start

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,14 +1,3 @@
-FROM openshift/origin-release:golang-1.10
-
-RUN mkdir -p /go/src/github.com/embercsi/ember-csi-operator/
-RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-
-COPY . /go/src/github.com/embercsi/ember-csi-operator/
-WORKDIR /go/src/github.com/embercsi/ember-csi-operator/
-
-RUN make dep
-RUN make compile
-
 FROM centos:7
 
 RUN yum update -y && yum clean all
@@ -17,4 +6,4 @@ RUN mkdir /etc/ember-csi-operator && chmod 755 /etc/ember-csi-operator
 ADD build/config.yml /etc/ember-csi-operator/config.yml
 USER nobody
 
-COPY --from=0 /go/src/github.com/embercsi/ember-csi-operator/build/ember-csi-operator /usr/local/bin/ember-csi-operator
+COPY ./ember-csi-operator /usr/local/bin/ember-csi-operator

--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -1,0 +1,10 @@
+FROM openshift/origin-release:golang-1.10
+
+RUN mkdir -p /go/src/github.com/embercsi/ember-csi-operator/
+RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+
+COPY . /go/src/github.com/embercsi/ember-csi-operator/
+WORKDIR /go/src/github.com/embercsi/ember-csi-operator/
+
+RUN make dep
+RUN make compile

--- a/build/Dockerfile.multistage
+++ b/build/Dockerfile.multistage
@@ -1,0 +1,20 @@
+FROM openshift/origin-release:golang-1.10
+
+RUN mkdir -p /go/src/github.com/embercsi/ember-csi-operator/
+RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+
+COPY . /go/src/github.com/embercsi/ember-csi-operator/
+WORKDIR /go/src/github.com/embercsi/ember-csi-operator/
+
+RUN make dep
+RUN make compile
+
+FROM centos:7
+
+RUN yum update -y && yum clean all
+
+RUN mkdir /etc/ember-csi-operator && chmod 755 /etc/ember-csi-operator
+ADD build/config.yml /etc/ember-csi-operator/config.yml
+USER nobody
+
+COPY --from=0 /go/src/github.com/embercsi/ember-csi-operator/build/ember-csi-operator /usr/local/bin/ember-csi-operator


### PR DESCRIPTION
This allows building the ember-csi-operator container even if multistage
builds are not supported (eg. when using older Docker releases).

Closes embercsi/ember-csi-operator#24