### PR TITLE
Remove build/_output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 # Temporary Build Files
 tmp/_output
+build/_output
 tmp/_test
 
 


### PR DESCRIPTION
We should not store build artifacts in the repository - this increases
the repo size over time to unusable sizes, because all of them are
stored in the git history.