### PR TITLE
Update config.yaml and set default to CSI spec v0.3

### DIFF
--- a/build/config.yaml
+++ b/build/config.yaml
@@ -2,23 +2,33 @@
 version: 1.0
 sidecars:
   default:
-    X_CSI_SPEC_VERSION: v0.2
-    external-attacher: quay.io/k8scsi/csi-attacher:v0.3.0
-    external-provisioner: quay.io/k8scsi/csi-provisioner:v0.3.0
-    driver-registrar: quay.io/k8scsi/driver-registrar:v0.3.0
+    X_CSI_SPEC_VERSION: v0.3
+    external-attacher: quay.io/k8scsi/csi-attacher:v0.4.2
+    external-provisioner: quay.io/k8scsi/csi-provisioner:v0.4.2
+    driver-registrar: quay.io/k8scsi/driver-registrar:v0.4.2
+    external-snapshotter: quay.io/k8scsi/csi-snapshotter:v0.4.1
 
   ocp-3.11:
     X_CSI_SPEC_VERSION: v0.3
     external-attacher: quay.io/k8scsi/csi-attacher:v0.4.2
     external-provisioner: quay.io/k8scsi/csi-provisioner:v0.4.2
     driver-registrar: quay.io/k8scsi/driver-registrar:v0.4.2
+    external-snapshotter: quay.io/k8scsi/csi-snapshotter:v0.4.1
+
+  k8s-v1.11:
+    X_CSI_SPEC_VERSION: v0.3
+    external-attacher: quay.io/k8scsi/csi-attacher:v0.4.2
+    external-provisioner: quay.io/k8scsi/csi-provisioner:v0.4.2
+    driver-registrar: quay.io/k8scsi/driver-registrar:v0.4.2
+    external-snapshotter: quay.io/k8scsi/csi-snapshotter:v0.4.1
 
   k8s-v1.13:
     X_CSI_SPEC_VERSION: v1.0
-    external-attacher: quay.io/k8scsi/csi-attacher:v1.0.1
-    external-provisioner: quay.io/k8scsi/csi-provisioner:v1.0.1
+    external-attacher: quay.io/k8scsi/csi-attacher:v1.1.1
+    external-provisioner: quay.io/k8scsi/csi-provisioner:v1.1.0
     cluster-driver-registrar: quay.io/k8scsi/csi-cluster-driver-registrar:v1.0.1
-    node-driver-registrar: quay.io/k8scsi/csi-node-driver-registrar:v1.0.2
-    external-snapshotter: quay.io/k8scsi/csi-snapshotter:v1.0.1 
+    node-driver-registrar: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+    external-snapshotter: quay.io/k8scsi/csi-snapshotter:v1.1.0
+
 drivers:
   default: embercsi/ember-csi:master

--- a/deploy/02-operator.yaml
+++ b/deploy/02-operator.yaml
@@ -35,7 +35,7 @@ spec:
             failureThreshold: 1
           env:
             - name: X_EMBER_OPERATOR_CLUSTER
-              value: k8s-v1.13
+              value: default # currently supported: default, ocp-3.11, k8s-v1.11, k8s-v1.13
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Add/update sections for k8s-1.11 and k8s-1.13 sidecar image versions
based on https://kubernetes-csi.github.io/docs/sidecar-containers.html

Also changes the example deployment to use the default sidecar images
that are used for CSI spec v0.3.