### PR TITLE
Bugfixes for OCP 4.x defaults

### DIFF
--- a/deploy/examples/drivers/3par.yaml
+++ b/deploy/examples/drivers/3par.yaml
@@ -6,5 +6,6 @@ metadata:
 spec:
   config:
     envVars:
+      X_CSI_EMBER_CONFIG:             '{"plugin_name": "my-3par"}'
       X_CSI_PERSISTENCE_CONFIG:       '{"storage":"crd"}'
       X_CSI_BACKEND_CONFIG :          '{"name":"3par", "driver":"HPE3PARISCSI", "san_ip":"1.2.3.4", "hpe3par_api_url": "https://w.x.y.z:8080/api/v1", "hpe3par_username": "user", "hpe3par_password": "toomanysecrets", "hpe3par_cpg": "CPG_name", "san_ip": "w.x.y.z", "san_login": "user", "san_password": "toomanysecrets",  "hpe3par_iscsi_ips": "w.x.y2.z2,w.x.y2.z3,w.x.y2.z4,w.x.y2.z4", "hpe3par_debug": false, "hpe3par_iscsi_chap_enabled": false, "hpe3par_snapshot_retention": 0, "hpe3par_snapshot_expiration": 1, "use_multipath_for_image_xfer": true }'

--- a/deploy/examples/drivers/ceph-with-topology.yaml
+++ b/deploy/examples/drivers/ceph-with-topology.yaml
@@ -15,6 +15,7 @@ spec:
             - node2.example.com
   config:
     envVars:
+      X_CSI_EMBER_CONFIG:             '{"plugin_name": "my-ceph-with-topologies"}'
       X_CSI_PERSISTENCE_CONFIG:       '{"storage":"crd"}'
       X_CSI_BACKEND_CONFIG :          '{"name": "rbd", "driver": "RBD", "rbd_user": "cinder", "rbd_pool": "cinder_volumes", "rbd_ceph_conf": "/etc/ceph/ceph.conf", "rbd_keyring_conf": "/etc/ceph/keyring"}'
     sysFiles:

--- a/deploy/examples/drivers/ceph.yaml
+++ b/deploy/examples/drivers/ceph.yaml
@@ -8,6 +8,7 @@ spec:
   config:
     envVars:
       X_CSI_PERSISTENCE_CONFIG:       '{"storage":"crd"}'
+      X_CSI_EMBER_CONFIG:             '{"plugin_name": "my-ceph"}'
       X_CSI_BACKEND_CONFIG :          '{"name": "rbd", "driver": "RBD", "rbd_user": "admin", "rbd_pool": "cephfs_data", "rbd_ceph_conf": "/etc/ceph/ceph.conf", "rbd_keyring_conf": "/etc/ceph/ceph.client.admin.keyring"}'
     sysFiles:
       name: sysfiles-secret

--- a/deploy/examples/drivers/kaminario.yaml
+++ b/deploy/examples/drivers/kaminario.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   config:
     envVars:
+      X_CSI_EMBER_CONFIG:             '{"plugin_name": "my-kaminario"}'
       X_CSI_PERSISTENCE_CONFIG:       '{"storage":"crd"}'
       X_CSI_BACKEND_CONFIG :          '{"name":"kaminario","driver":"KaminarioISCSI","san_ip":"1.2.3.4","use_multipath_for_image_xfer": "true","san_login":"someusername","san_password":"somesecretpassword"}'
 

--- a/deploy/examples/drivers/lvm.yaml
+++ b/deploy/examples/drivers/lvm.yaml
@@ -6,5 +6,6 @@ metadata:
 spec:
   config:
     envVars:
+      X_CSI_EMBER_CONFIG:             '{"plugin_name": "my-lvm"}'
       X_CSI_PERSISTENCE_CONFIG:       '{"storage":"crd"}'
       X_CSI_BACKEND_CONFIG :          '{"name": "lvm", "driver": "LVMVolum", "volume_group": "ember-volumes", "target_protocol": "iscsi", "iscsi_ip_address":"192.168.10.100", "target_helper": "lioadm"}' 

--- a/deploy/examples/drivers/qnap.yaml
+++ b/deploy/examples/drivers/qnap.yaml
@@ -6,5 +6,6 @@ metadata:
 spec:
   config:
     envVars:
+      X_CSI_EMBER_CONFIG:             '{"plugin_name": "my-qnap"}'
       X_CSI_PERSISTENCE_CONFIG:       '{"storage":"crd"}'
       X_CSI_BACKEND_CONFIG :          '{ "name": "qnap", "driver": "QnapISCSI", "use_multipath_for_image_xfer": true, "qnap_management_url": "https://w.x.y.z:443", "iscsi_ip_address": "w.x.y.z", "qnap_storage_protocol": "iscsi", "qnap_poolname": "Storage Pool 1", "san_login": "admin", "san_password": "toomanysecrets" }'

--- a/deploy/examples/drivers/solidfire.yaml
+++ b/deploy/examples/drivers/solidfire.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   config:
     envVars:
+      X_CSI_EMBER_CONFIG:             '{"plugin_name": "my-solidfire"}'
       X_CSI_PERSISTENCE_CONFIG:       '{"storage":"crd"}'
       X_CSI_BACKEND_CONFIG :          '{"name":"solidfire", "driver":"SolidFire", "san_ip":"1.2.3.4", "san_login":"someusername", "san_password":"somesecretpassword", "sf_allow_template_caching":"false", "image_volume_cache_enabled":"true", "volume_clear":"zero"}'
 

--- a/deploy/examples/drivers/synology.yaml
+++ b/deploy/examples/drivers/synology.yaml
@@ -6,5 +6,6 @@ metadata:
 spec:
   config:
     envVars:
+      X_CSI_EMBER_CONFIG:             '{"plugin_name": "my-synology"}'
       X_CSI_PERSISTENCE_CONFIG:       '{"storage":"crd"}'
       X_CSI_BACKEND_CONFIG :          '{ "name": "synology", "driver": "SynoISCSI", "iscsi_protocol": "iscsi", "target_ip_address": "synology.example.com", "synology_admin_port": 5001, "synology_username": "admin", "synology_password": "toomanysecrets", "synology_pool_name": "volume1", "driver_use_ssl": true }'

--- a/deploy/examples/drivers/vmax.yaml
+++ b/deploy/examples/drivers/vmax.yaml
@@ -6,5 +6,6 @@ metadata:
 spec:
   config:
     envVars:
+      X_CSI_EMBER_CONFIG:             '{"plugin_name": "my-dell-emc-vmax"}'
       X_CSI_PERSISTENCE_CONFIG:       '{"storage":"crd"}'
       X_CSI_BACKEND_CONFIG :          '{"name":"VMAX_ISCSI_DIAMOND", "driver":"VMAXISCSI", "san_ip":"1.2.3.4", "san_login":"someusername", "san_password":"somesecretpassword", "san_reset_port":"8443", "vmax_srp":"SRP_1", "vmax_array":"0001919191919", "vmax_port_groups": [ "os-iscsi-pg" ], "image_volume_cache_enabled":"true", "volume_clear":"zero"}' 

--- a/deploy/examples/drivers/xtremio-fc.yaml
+++ b/deploy/examples/drivers/xtremio-fc.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   config:
     envVars:
+      X_CSI_EMBER_CONFIG:             '{"plugin_name": "my-xtremio-fc"}'
       X_CSI_PERSISTENCE_CONFIG:       '{"storage":"crd"}'
       X_CSI_BACKEND_CONFIG :          '{"name":"xtremio","driver":"XtremIOFC","san_ip":"1.2.3.4", "use_multipath_for_image_xfer": "true", "xtremio_cluster_name":"exampleclustername","san_login":"someusername","san_password":"somesecretpassword"}'
 

--- a/deploy/examples/drivers/xtremio-iscsi.yaml
+++ b/deploy/examples/drivers/xtremio-iscsi.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   config:
     envVars:
+      X_CSI_EMBER_CONFIG:             '{"plugin_name": "my-xtremio-iscsi"}'
       X_CSI_PERSISTENCE_CONFIG:       '{"storage":"crd"}'
       X_CSI_BACKEND_CONFIG :          '{"name":"xtremio","driver":"XtremIOISCSI","san_ip":"1.2.3.4","use_multipath_for_image_xfer": "true","xtremio_cluster_name":"exampleclustername","san_login":"someusername","san_password":"somesecretpassword"}'
 

--- a/pkg/controller/embercsi/common.go
+++ b/pkg/controller/embercsi/common.go
@@ -294,8 +294,8 @@ func generateVolumeMounts(ecsi *embercsiv1alpha1.EmberCSI, csiDriverMode string)
 		},
 		)
 
-		// ocp
-		if strings.Contains(Cluster, "ocp") || Cluster == "default" {
+		// ocp 3.x
+		if strings.Contains(Cluster, "ocp-3") {
 			vm = append(vm, corev1.VolumeMount{
 				Name:             "mountpoint-dir",
 				MountPropagation: &bidirectional,
@@ -306,7 +306,7 @@ func generateVolumeMounts(ecsi *embercsiv1alpha1.EmberCSI, csiDriverMode string)
 				MountPropagation: &bidirectional,
 			},
 			)
-		} else { // k8s
+		} else { // k8s, ocp >= 4.x
 			vm = append(vm, corev1.VolumeMount{
 				Name:             "mountpoint-dir",
 				MountPropagation: &bidirectional,
@@ -454,8 +454,8 @@ func generateVolumes(ecsi *embercsiv1alpha1.EmberCSI, csiDriverMode string) []co
 			},
 		},
 		)
-		// ocp
-		if strings.Contains(Cluster, "ocp") || Cluster == "default" {
+		// ocp 3.x
+		if strings.Contains(Cluster, "ocp-3") {
 			vol = append(vol, corev1.Volume{
 				Name: "mountpoint-dir",
 				VolumeSource: corev1.VolumeSource{
@@ -473,7 +473,7 @@ func generateVolumes(ecsi *embercsiv1alpha1.EmberCSI, csiDriverMode string) []co
 				},
 			},
 			)
-		} else { // k8s
+		} else { // k8s, ocp >= 4.x
 			vol = append(vol, corev1.Volume{
 				Name: "mountpoint-dir",
 				VolumeSource: corev1.VolumeSource{


### PR DESCRIPTION
These two changes will fix the defaults when using an OCP 4.x cluster.

It is possible to use OCP 4.x using slightly modified deployment .yamls, however this should be the default to make it easier for our users.