### PR TITLE
Add script to generate form config options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ tramp
 .org-id-locations
 *_archive
 
+build/olm-catalog/out.yaml
 # flymake-mode
 *_flymake.*
 

--- a/build/olm-catalog/olm-csv-gen.sh
+++ b/build/olm-catalog/olm-csv-gen.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# The Python script accepts CONSOLE_VERSION and DEVLOPMENT env variables
+TAG="${1:-master}"
+
+if [[ -z "${DEVELOPMENT}" ]]; then
+  dest=../../deploy/olm-catalog/next
+  dest_file=${2:-$dest/ember-csi-operator.vX.Y.Z.clusterserviceversion.yaml}
+  mkdir -p $dest
+else
+  dest_file=./out.yaml
+fi
+
+echo "Getting driver config from tag $TAG and writing result to $dest_file"
+docker run --rm embercsi/ember-csi:$TAG ember-list-drivers -d | python ./yaml-options-gen.py > $dest_file

--- a/build/olm-catalog/template-dev.yaml
+++ b/build/olm-catalog/template-dev.yaml
@@ -1,0 +1,559 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    certified: 'false'
+    olm.targetNamespaces: default
+    repository: 'https://github.com/embercsi/ember-csi-operator'
+    support: 'http://readthedocs.org/projects/ember-csi/'
+    # BEGIN AUTO GENERATED EXAMPLES
+${SAMPLE_CONFIG}
+    # END AUTO GENERATED EXAMPLES
+    capabilities: Basic Install
+    olm.operatorNamespace: default
+    containerImage: 'docker.io/embercsi/ember-csi-operator:latest'
+    createdAt: '2019-08-12:22:09:00'
+    categories: Storage
+    description: >-
+      Operator to deploy Ember-CSI, a multi-vendor CSI plugin driver supporting
+      over 80 storage drivers in a single plugin to provide block and mount
+      storage to container orchestration systems
+    olm.operatorGroup: default-xkq2c
+  selfLink: >-
+    /apis/operators.coreos.com/v1alpha1/namespaces/default/clusterserviceversions/ember-csi-operator.v0.0.1
+  name: ember-csi-operator.v0.0.1
+  creationTimestamp: '2020-03-11T17:48:47Z'
+  generation: 1
+  namespace: default
+  labels:
+    olm.api.4627b83107910880: provided
+  resourceVersion: '1001972'
+spec:
+  customresourcedefinitions:
+    owned:
+      - description: Represents a deployment of EmberCSI driver
+        displayName: Deployments
+        kind: EmberCSI
+        name: embercsis.ember-csi.io
+        resources:
+          - kind: StorageClass
+            name: ''
+            version: v1
+          - kind: StatefulSet
+            name: ''
+            version: v1
+          - kind: EmberCSI
+            name: ''
+            version: v1alpha
+          - kind: Daemonset
+            name: ''
+            version: v1
+        specDescriptors:
+          - description: Define which Nodes the Pods are scheduled on.
+            displayName: nodeSelect
+            path: nodeSelector
+          - description: Ember CSI driver container image to use
+            displayName: image
+            path: image
+          - description: Config for Ember
+            displayName: config
+            path: config
+          - description: Tolerations
+            displayName: tolerations
+            path: tolerations
+          - description: Topologies
+            displayName: topologies
+            path: topologies
+          # BEGIN AUTO GENERATED CONFIGURATION OPTIONS
+${DRIVER_OPTIONS}
+          # END AUTO GENERATED CONFIGURATION OPTIONS
+        statusDescriptors:
+          - description: The installed Ember CSI version
+            displayName: Version
+            path: version
+        version: v1alpha1
+  apiservicedefinitions: {}
+  keywords:
+    - Ember-CSI
+    - CSI
+  displayName: Ember CSI Operator
+  provider:
+    name: Red Hat
+  maturity: alpha
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: false
+      type: AllNamespaces
+  version: 0.0.1
+  icon:
+    - base64data: >-
+        PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjxzdmcKICAgeG1sbnM6ZGM9Imh0dHA6Ly9wdXJsLm9yZy9kYy9lbGVtZW50cy8xLjEvIgogICB4bWxuczpjYz0iaHR0cDovL2NyZWF0aXZlY29tbW9ucy5vcmcvbnMjIgogICB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiCiAgIHhtbG5zOnN2Zz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgdmlld0JveD0iMCAwIDEwNi41NDIzMiAxMzguNzkwODUiCiAgIGhlaWdodD0iMTM4Ljc5MDg1IgogICB3aWR0aD0iMTA2LjU0MjMyIgogICB4bWw6c3BhY2U9InByZXNlcnZlIgogICBpZD0ic3ZnNDc2NiIKICAgdmVyc2lvbj0iMS4xIj48bWV0YWRhdGEKICAgICBpZD0ibWV0YWRhdGE0NzcyIj48cmRmOlJERj48Y2M6V29yawogICAgICAgICByZGY6YWJvdXQ9IiI+PGRjOmZvcm1hdD5pbWFnZS9zdmcreG1sPC9kYzpmb3JtYXQ+PGRjOnR5cGUKICAgICAgICAgICByZGY6cmVzb3VyY2U9Imh0dHA6Ly9wdXJsLm9yZy9kYy9kY21pdHlwZS9TdGlsbEltYWdlIiAvPjxkYzp0aXRsZT48L2RjOnRpdGxlPjwvY2M6V29yaz48L3JkZjpSREY+PC9tZXRhZGF0YT48ZGVmcwogICAgIGlkPSJkZWZzNDc3MCI+PGNsaXBQYXRoCiAgICAgICBpZD0iY2xpcFBhdGg0NzgyIgogICAgICAgY2xpcFBhdGhVbml0cz0idXNlclNwYWNlT25Vc2UiPjxwYXRoCiAgICAgICAgIGlkPSJwYXRoNDc4MCIKICAgICAgICAgZD0iTSAwLDE1MCBIIDMwMCBWIDAgSCAwIFoiIC8+PC9jbGlwUGF0aD48L2RlZnM+PGcKICAgICB0cmFuc2Zvcm09Im1hdHJpeCgxLjMzMzMzMzMsMCwwLC0xLjMzMzMzMzMsLTEwMS45OTEyNSwxODIuNzI5MikiCiAgICAgaWQ9Imc0Nzc0Ij48ZwogICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTMzLjU1MzI1MikiCiAgICAgICBpZD0iZzQ5MzUiPjxnCiAgICAgICAgIGlkPSJnNDc4NCIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTQyLjAwMzksNzcuNjA3OSkiPjxwYXRoCiAgICAgICAgICAgZD0ibSAwLDAgYyAyLjY1NywtMC45ODMgMy4wOTgsLTIuNjA3IDMuOTE2LC00LjMxMiAwLjgxOCwtMS43MDUgMC44ODUsLTMuNjQxIDEuMTI0LC01LjUwOCAwLjIzOCwtMS44NjYgMC43MjYsLTMuODI3IDIuMTQ0LC01LjEyMSAxLjM3OSwtMS4yNTkgMy41NTUsLTEuNjUzIDUuMzQyLC0wLjk2OCAxLjc4NywwLjY4NyAzLjA5LDIuNDE1IDMuMTk4LDQuMjQ1IDAuMTE3LDEuOTgyIC0xLjI4NCw0LjgwMSAtMi42NSw2LjI4MiBDIDkuNzE5LC0xLjc0NCA1LjA4NSwtMC4zOTkgMCwwIgogICAgICAgICAgIHN0eWxlPSJmaWxsOiNlOWFhMjk7ZmlsbC1vcGFjaXR5OjE7ZmlsbC1ydWxlOm5vbnplcm87c3Ryb2tlOm5vbmUiCiAgICAgICAgICAgaWQ9InBhdGg0Nzg2IiAvPjwvZz48ZwogICAgICAgICBpZD0iZzQ3ODgiCiAgICAgICAgIHRyYW5zZm9ybT0idHJhbnNsYXRlKDE4NS4xNDY1LDkwLjU5NTIpIj48cGF0aAogICAgICAgICAgIGQ9Im0gMCwwIGMgMy41MzMsLTYuMDk5IDUuMTQyLC0xMy4zNzQgNC43NDksLTIwLjU5NyAtMC41MiwtNy4yMDEgLTIuODkyLC0xNC40MzEgLTcuMjczLC0yMC4zNzUgLTEuMDA2LC0xLjU1MSAtMi4yODgsLTIuODgzIC0zLjQ4MiwtNC4yOTYgLTAuNjQxLC0wLjY2MyAtMS4zMzUsLTEuMjc1IC0yLjAwNSwtMS45MTQgLTAuMzQsLTAuMzE0IC0wLjY3LC0wLjYzOSAtMS4wMTksLTAuOTQyIGwgLTEuMDk3LC0wLjg1IGMgLTIuODU5LC0yLjM2NSAtNi4xNTEsLTQuMTYyIC05LjU1MiwtNS42NTMgbCAtMi42MSwtMC45OTMgYyAtMC44NzUsLTAuMzE4IC0xLjc5MywtMC41IC0yLjY5LC0wLjc1NCAtMS43ODYsLTAuNTUxIC0zLjY1MSwtMC43MTkgLTUuNDg3LC0xLjAzOCAtMy43MDIsLTAuMyAtNy40NjMsLTAuMzk4IC0xMS4xNDQsMC4yODYgbCAtMS4zODIsMC4yMTcgYyAtMC40NiwwLjA4IC0wLjkwNiwwLjIyNSAtMS4zNTksMC4zMzQgbCAtMi43MDcsMC43MTQgLTIuNjI2LDAuOTY3IGMgLTAuNDM2LDAuMTY3IC0wLjg3OCwwLjMxNyAtMS4zMDYsMC40OTkgbCAtMS4yNTgsMC42MTEgYyAtMy40MDYsMS41MjkgLTYuNDk5LDMuNjggLTkuMzIsNi4wODggbCAtMi4wMzQsMS45MDggYyAtMC42NjIsMC42NTEgLTEuMjQzLDEuMzggLTEuODY2LDIuMDY3IGwgLTAuOTE4LDEuMDQ2IGMgLTAuMjg3LDAuMzYzIC0wLjU1LDAuNzQ3IC0wLjgyNSwxLjEyIC0wLjUzOSwwLjc1NCAtMS4wOTcsMS40OTUgLTEuNjE2LDIuMjYgLTEuOTY0LDMuMTQyIC0zLjU4MSw2LjQ5OCAtNC42MTksMTAuMDQyIC0wLjk3NywzLjU0MyAtMS43MDMsNy4xODMgLTEuNjQyLDEwLjg0OCAtMC4wOTYsMy42NTEgMC4zOTcsNy4yOTggMS4zNDYsMTAuNzg5IDEuOTQyLDYuOTc0IDUuODQxLDEzLjMyNCAxMS4xMzksMTcuOTY2IC00LjQ4OCwtNS40MDkgLTcuNTY0LC0xMS44MTYgLTguNzQ2LC0xOC41MTcgLTAuNjE2LC0zLjMzNiAtMC44MjMsLTYuNzQ1IC0wLjQ2NSwtMTAuMDkxIDAuMTk5LC0zLjM1OCAxLjAwNiwtNi42MzUgMi4wNzQsLTkuNzc4IDQuNCwtMTIuNjE4IDE1Ljk1OCwtMjIuMTcyIDI4Ljk0MSwtMjQuMTYgMy4yMjMsLTAuNjQ3IDYuNTQyLC0wLjU3OSA5LjgxMiwtMC4zNjMgMS42MTcsMC4yNzUgMy4yNjgsMC4zODUgNC44NDUsMC44NjUgMC43OTEsMC4yMTggMS42MDYsMC4zNiAyLjM4LDAuNjM1IGwgMi4zMjgsMC44MTQgYyAzLjA0MywxLjIyMiA2LjAzMiwyLjcwNyA4LjY1LDQuNzQgbCAxLjAwOSwwLjcyNCBjIDAuMzIxLDAuMjYgMC42MjQsMC41NDMgMC45MzcsMC44MTQgbCAxLjg2NywxLjY0MiBjIDEuMTI5LDEuMjExIDIuMzY3LDIuMzQxIDMuMzQzLDMuNjk0IDQuMjE1LDUuMTc0IDYuODkzLDExLjU2OCA3Ljk0NywxOC4yNzcgQyAzLjMzOCwtMTMuNjE5IDIuNTI3LC02LjU2MiAwLDAiCiAgICAgICAgICAgc3R5bGU9ImZpbGw6I2UxNzUxYztmaWxsLW9wYWNpdHk6MTtmaWxsLXJ1bGU6bm9uemVybztzdHJva2U6bm9uZSIKICAgICAgICAgICBpZD0icGF0aDQ3OTAiIC8+PC9nPjxnCiAgICAgICAgIGlkPSJnNDc5MiIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTQ4LjIzNzMsNDYuNTY5MykiPjxwYXRoCiAgICAgICAgICAgZD0ibSAwLDAgYyAxLjU3MSwtMC4xNjIgMy4xNTQsLTAuMjA5IDQuNzMyLC0wLjEzIDMuMzQ0LDAuMTY3IDYuNjUsMC45MSA5LjczMywyLjIxOSAyLjMzMSwwLjk4OCA2LjI1LDIuNjcyIDcuNjMyLDQuODY1IDIuMjcsMy42MDMgMi4wODQsOS4yMSAxLjQ4MywxMy4yNTQgLTEuNDc5LDkuOTYyIC05Ljk4NCwxOC40NyAtMTkuNTQ1LDIxLjc4OSA0LjI4OSwtMS40ODggOC4zOSwtNS43MzkgMTAuNzAyLC05LjY3OSAyLjUxMywtNC4yOCAyLjUzOCwtOC43MTQgMC44MzgsLTEzLjEyIC0yLjE1OCwtNS41OTIgLTcuMTU5LC04LjgxMyAtMTMuMDk5LC04LjgxMyAtNy4xNCwwIC0xMy44NzMsNS45MTIgLTE0LjIzLDEzLjIyNyAtMC40MDIsOC4yMzkgNi41NjgsMTYuNDIxIDExLjI2OSwyMi40NzggMTMuNzc5LDE3Ljc1OCAyLjgsNDQuMzg0IDIuNzk4LDQ0LjM4NyBDIDEuNDk1LDgwLjk1MyAtMC44MjYsNzIuMDMgLTcuMDYzLDY0LjcyIC0xMi41Nyw1OC4yNjUgLTE5LjU4OCw1Mi45NzQgLTIzLjgwOCw0NS40OTMgYyAtMS45NzgsLTMuNTA2IC0zLjM1NiwtNy4zNzEgLTMuODc3LC0xMS44NzcgLTAuODQyLC03LjI2OSAwLjg5OCwtMTQuODE0IDUuMTEzLC0yMC44MjcgQyAtMTcuNDI2LDUuNDQ4IC04Ljg0MSwwLjkwNyAwLDAiCiAgICAgICAgICAgc3R5bGU9ImZpbGw6I2IxNDkyZTtmaWxsLW9wYWNpdHk6MTtmaWxsLXJ1bGU6bm9uemVybztzdHJva2U6bm9uZSIKICAgICAgICAgICBpZD0icGF0aDQ3OTQiIC8+PC9nPjxnCiAgICAgICAgIGlkPSJnNDc5NiIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTQ5LjU5NDIsNDYuNDYxOSkiPjxwYXRoCiAgICAgICAgICAgZD0ibSAwLDAgYyAwLjM5LC0wLjAyMiAwLjc3OCwtMC4wNCAxLjE2NCwtMC4wNDkgLTkuNTg2LDQuMDM1IC0xNC4zMTEsMTEuNTQ3IC0xNS4zMDIsMjAuNDI5IC0wLjUwNiw0LjU0MSAwLjkxMyw4Ljg5MSAzLjI3OSwxMi42ODMgMi4zNjQsNC44NjIgNi4xMiw5LjQwMiA5LjAxNywxMy4xMzUgMTMuNzc5LDE3Ljc1NyAyLjgsNDQuMzg0IDIuNzk5LDQ0LjM4NiBDIDAuMTM4LDgxLjA2MSAtMi4xODMsNzIuMTM4IC04LjQyLDY0LjgyNyAtMTMuOTI3LDU4LjM3MyAtMjAuOTQ1LDUzLjA4MSAtMjUuMTY1LDQ1LjYgYyAtMS45NzgsLTMuNTA2IC0zLjM1NiwtNy4zNzEgLTMuODc3LC0xMS44NzYgLTAuODQyLC03LjI3IDAuODk4LC0xNC44MTUgNS4xMTMsLTIwLjgyOCBDIC0xOC43ODMsNS41NTYgLTEwLjE5OCwxLjAxNSAtMS4zNTcsMC4xMDcgLTAuOTQ5LDAuMDY1IC0wLjU0MywwLjAzMyAtMC4xNDEsMC4wMDggLTAuMDk0LDAuMDA1IC0wLjA0NywwLjAwMyAwLDAiCiAgICAgICAgICAgc3R5bGU9ImZpbGw6I2Q3NzIzMDtmaWxsLW9wYWNpdHk6MTtmaWxsLXJ1bGU6bm9uemVybztzdHJva2U6bm9uZSIKICAgICAgICAgICBpZD0icGF0aDQ3OTgiIC8+PC9nPjxnCiAgICAgICAgIGlkPSJnNDgwMCIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTc0LjM5MjYsNTcuNDY4OCkiPjxwYXRoCiAgICAgICAgICAgZD0ibSAwLDAgYyA0LjQ5OSw1LjM3OCA1LjQ1NCwxMy45MzggNS40NDEsMTkuOTg4IC0wLjAxMiw2IC0xLjU1NywxMi4wNjEgLTUuMDM3LDE3LjI3NyAtMi44NTEsNC4yNzYgLTYuOTAxLDcuODcgLTEwLjI0LDExLjg4MSAtMy4zNCw0LjAxMiAtNi4wNDIsOC43NDggLTUuNTcsMTMuNjUxIC0yLjc5MiwtMy4wMDYgLTMuMzk0LC03LjAwNiAtMi42MTMsLTEwLjkyNCAwLjY4MywtMy40MjIgMi41MzcsLTYuNTczIDMuNzY4LC05Ljg0NCAwLjkxNywtMi40MzkgMS45MTUsLTQuODY2IDIuNDQ3LC03LjQyNiAwLjU4NSwtMi44MTYgMC4yOTMsLTUuMDQ1IC0wLjc1NSwtNy42NzkgMS41ODYsLTEuMzczIDMuMTYzLC0yLjk3NiA0LjI5NiwtNC43NTMgMS4xMzUsLTEuNzc3IDEuMzk4LC0zLjk1NCAyLjM5MiwtNS44MDQgMi4yNjYsLTQuMjIgMy4wMzcsLTkuMTE4IDIuNTQ2LC0xMy44OTgiCiAgICAgICAgICAgc3R5bGU9ImZpbGw6I2UwYTgzMjtmaWxsLW9wYWNpdHk6MTtmaWxsLXJ1bGU6bm9uemVybztzdHJva2U6bm9uZSIKICAgICAgICAgICBpZD0icGF0aDQ4MDIiIC8+PC9nPjxnCiAgICAgICAgIGlkPSJnNDgwNCIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTYyLjc5OTgsMTAyLjU3MjMpIj48cGF0aAogICAgICAgICAgIGQ9Ik0gMCwwIEMgLTMuMjI5LDQuNjc4IC02LjkwOCwxMi4wMjggLTMuODEzLDE3LjY5NCAtNi42MDUsMTQuNjg4IC03LjIwNywxMC42ODcgLTYuNDI2LDYuNzcgYyAwLjY4MywtMy40MjMgMi41MzYsLTYuNTc0IDMuNzY4LC05Ljg0NSAwLjkxNywtMi40MzggMS45MTUsLTQuODY2IDIuNDQ3LC03LjQyNSAwLjU4NSwtMi44MTcgMC4yOTMsLTUuMDQ2IC0wLjc1NSwtNy42NzkgMS41ODYsLTEuMzc0IDMuMTYyLC0yLjk3NiA0LjI5NiwtNC43NTMgMS4xMzUsLTEuNzc4IDEuMzk4LC0zLjk1NCAyLjM5MiwtNS44MDQgMC4yMjEsLTAuNDEzIDAuNDI0LC0wLjgzNSAwLjYxOCwtMS4yNiBsIDEuMDcsLTAuMDYyIGMgMCwwIDIuMjc1LDcuOTYyIDEuMjcyLDE1LjE4MiBDIDcuODcsLTkuMDQzIDMuMjA2LC00LjY0NSAwLDAiCiAgICAgICAgICAgc3R5bGU9ImZpbGw6I2MzNTAyZTtmaWxsLW9wYWNpdHk6MTtmaWxsLXJ1bGU6bm9uemVybztzdHJva2U6bm9uZSIKICAgICAgICAgICBpZD0icGF0aDQ4MDYiIC8+PC9nPjxnCiAgICAgICAgIGlkPSJnNDgwOCIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTUwLjc1ODMsNDYuNDEzMSkiPjxwYXRoCiAgICAgICAgICAgZD0ibSAwLDAgYyAwLDAgMTQuMTcsMy42OTEgMTYuNjY5LDE4Ljc5MyAyLjE4NiwxMy4yMDUgLTkuMTM3LDIxLjE4MyAtMTUuMTU1LDIzLjM2IDAsMCAxMy4xNzgsMC44OTggMjAuMTIxLC02Ljg0OSBDIDI4LjU3OSwyNy41NTggMjguMTEsMTkuMDg2IDI0LjI4OCwxMi4wNzEgMjAuMjIxLDQuNjA4IDkuMDE5LC0wLjY4MiAwLDAiCiAgICAgICAgICAgc3R5bGU9ImZpbGw6I2Q3NzIzMDtmaWxsLW9wYWNpdHk6MTtmaWxsLXJ1bGU6bm9uemVybztzdHJva2U6bm9uZSIKICAgICAgICAgICBpZD0icGF0aDQ4MTAiIC8+PC9nPjxnCiAgICAgICAgIGlkPSJnNDgxMiIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTUwLjc1ODMsNDYuNDEzMSkiPjxwYXRoCiAgICAgICAgICAgZD0iTSAwLDAgQyAxNS42MTcsMS4zMyAyMy45ODksMTQuMDQxIDIxLjQ1MywyNi4yNDEgMTkuMDc1LDM3LjY3NyAxLjUxNCw0Mi4xNTMgMS41MTQsNDIuMTUzIDcuNTMyLDM5Ljk3NiAxOC44NTUsMzEuOTk4IDE2LjY2OSwxOC43OTMgMTQuMTcsMy42OTEgMCwwIDAsMCIKICAgICAgICAgICBzdHlsZT0iZmlsbDojZTBhODMyO2ZpbGwtb3BhY2l0eToxO2ZpbGwtcnVsZTpub256ZXJvO3N0cm9rZTpub25lIgogICAgICAgICAgIGlkPSJwYXRoNDgxNCIgLz48L2c+PGcKICAgICAgICAgaWQ9Imc0ODE2IgogICAgICAgICB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxMjcuNTkxMyw3Ni45MjI5KSI+PHBhdGgKICAgICAgICAgICBkPSJtIDAsMCBjIDEuMDk0LDkuMjEzIDcuMTk4LDE1LjYzIDEyLjk5LDIyLjQwMiA0LjgyMiw1LjYzOCA5LjA1NiwxMS45NTUgMTAuNTkzLDE5LjMxMyAxLjIzOCw1LjkzNSAxLjMsMTIuNTkgLTAuNjI0LDE4LjQwOSBDIDIyLjE0MSw1MC42IDE5LjgyLDQxLjY3NyAxMy41ODMsMzQuMzY2IDguMDc2LDI3LjkxMiAxLjA1OCwyMi42MiAtMy4xNjIsMTUuMTM5IC01LjE0LDExLjYzMyAtNi41MTgsNy43NjggLTcuMDM5LDMuMjYzIGMgLTAuODQyLC03LjI3IDAuODk4LC0xNC44MTUgNS4xMTMsLTIwLjgyNyA1LjE0NiwtNy4zNDEgMTMuNzMxLC0xMS44ODIgMjIuNTcyLC0xMi43OSAwLjQwOCwtMC4wNDIgMC44MTMsLTAuMDc0IDEuMjE2LC0wLjA5OSAwLjA0NywtMC4wMDMgMC4wOTQsLTAuMDA1IDAuMTQxLC0wLjAwOCAwLjM5LC0wLjAyMiAwLjc3OCwtMC4wNCAxLjE2NCwtMC4wNDkgLTYuNDU0LDAuODgzIC0xMi4yNTQsMy4xMjggLTE2LjQ2MSw3LjQ3IEMgMC45NTQsLTE3LjEwMyAtMC45NTEsLTguMDEgMCwwIgogICAgICAgICAgIHN0eWxlPSJmaWxsOiNlMGE4MzI7ZmlsbC1vcGFjaXR5OjE7ZmlsbC1ydWxlOm5vbnplcm87c3Ryb2tlOm5vbmUiCiAgICAgICAgICAgaWQ9InBhdGg0ODE4IiAvPjwvZz48L2c+PC9nPjwvc3ZnPg==
+      mediatype: image/svg+xml
+  minKubeVersion: 1.11.0
+  links:
+    - name: Learn more about the project
+      url: 'http://ember-csi.io/'
+    - name: Documentation
+      url: 'http://readthedocs.org/projects/ember-csi/'
+    - name: Ember-CSI Source Code
+      url: 'https://github.com/embercsi/ember-csi'
+    - name: Ember-CSI Operator Source Code
+      url: 'https://github.com/embercsi/ember-csi-operator'
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - security.openshift.io
+              resourceNames:
+                - privileged
+                - hostmount-anyuid
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - use
+            - apiGroups:
+                - ember-csi.io
+              resources:
+                - '*'
+              verbs:
+                - '*'
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterrole
+                - clusterrolebindings
+                - role
+                - rolebindings
+                - serviceaccounts
+              verbs:
+                - get
+                - create
+                - delete
+                - patch
+                - update
+            - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - list
+                - create
+            - apiGroups:
+                - ''
+              resources:
+                - nodes
+              verbs:
+                - '*'
+            - apiGroups:
+                - ''
+              resources:
+                - secrets
+              verbs:
+                - get
+                - list
+            - apiGroups:
+                - ''
+              resources:
+                - persistentvolumes
+              verbs:
+                - create
+                - delete
+                - list
+                - get
+                - watch
+                - update
+            - apiGroups:
+                - ''
+              resources:
+                - persistentvolumeclaims
+              verbs:
+                - get
+                - list
+                - watch
+                - update
+            - apiGroups:
+                - storage.k8s.io
+              resources:
+                - volumeattachments
+              verbs:
+                - get
+                - list
+                - watch
+                - update
+                - delete
+                - create
+            - apiGroups:
+                - storage.k8s.io
+              resources:
+                - storageclasses
+                - csinodes
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+                - update
+                - delete
+            - apiGroups:
+                - '*'
+              resources:
+                - events
+              verbs:
+                - create
+                - list
+                - watch
+                - update
+                - delete
+            - apiGroups:
+                - snapshot.storage.k8s.io
+              resources:
+                - volumesnapshotclasses
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
+            - apiGroups:
+                - snapshot.storage.k8s.io
+              resources:
+                - volumesnapshotcontents
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+                - update
+                - delete
+            - apiGroups:
+                - snapshot.storage.k8s.io
+              resources:
+                - volumesnapshots
+              verbs:
+                - get
+                - list
+                - watch
+                - update
+            - apiGroups:
+                - csi.storage.k8s.io
+              resources:
+                - csidrivers
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+                - update
+                - delete
+          serviceAccountName: ember-csi-operator
+      deployments:
+        - name: ember-csi-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: ember-csi-operator
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  name: ember-csi-operator
+              spec:
+                containers:
+                  - command:
+                      - ember-csi-operator
+                    env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: POD_NAME
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.name
+                      - name: OPERATOR_NAME
+                        value: ember-csi-operator
+                    image: 'docker.io/embercsi/ember-csi-operator:latest'
+                    imagePullPolicy: Always
+                    name: ember-csi-operator
+                    ports:
+                      - containerPort: 60000
+                        name: metrics
+                    readinessProbe:
+                      exec:
+                        command:
+                          - stat
+                          - /tmp/operator-sdk-ready
+                      failureThreshold: 1
+                      initialDelaySeconds: 4
+                      periodSeconds: 10
+                    resources: {}
+                serviceAccountName: ember-csi-operator
+      permissions:
+        - rules:
+            - apiGroups:
+                - ''
+              resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+              verbs:
+                - '*'
+            - apiGroups:
+                - ''
+              resources:
+                - namespaces
+              verbs:
+                - get
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+              verbs:
+                - '*'
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+              verbs:
+                - get
+                - create
+            - apiGroups:
+                - ember-csi.io
+              resources:
+                - '*'
+              verbs:
+                - '*'
+          serviceAccountName: ember-csi-operator
+    strategy: deployment
+  maintainers:
+    - email: geguileo@redhat.com
+      name: Gorka Eguileor
+    - email: cschwede@redhat.com
+      name: Christian Schwede
+    - email: kthyagar@redhat.com
+      name: Kiran Thyagaraja
+  description: >-
+    Operator to deploy Ember-CSI, a multi-vendor CSI plugin driver supporting
+    over 80 storage drivers in a single plugin to provide block and mount
+    storage to container orchestration systems.
+  selector:
+    matchLabels:
+      operated-by: ember-csi.io
+  labels:
+    operated-by: ember-csi.io
+status:
+  reason: InstallSucceeded
+  message: install strategy completed with no errors
+  lastUpdateTime: '2020-03-11T17:49:12Z'
+  requirementStatus:
+    - group: operators.coreos.com
+      kind: ClusterServiceVersion
+      message: CSV minKubeVersion (1.11.0) less than server version (v1.16.2)
+      name: ember-csi-operator.v0.0.1
+      status: Present
+      version: v1alpha1
+    - group: apiextensions.k8s.io
+      kind: CustomResourceDefinition
+      message: CRD is present and Established condition is true
+      name: embercsis.ember-csi.io
+      status: Present
+      uuid: 07dedd80-9757-4f91-a84a-7f51a086e942
+      version: v1beta1
+    - dependents:
+        - group: rbac.authorization.k8s.io
+          kind: PolicyRule
+          message: >-
+            namespaced
+            rule:{"verbs":["*"],"apiGroups":[""],"resources":["pods","services","endpoints","persistentvolumeclaims","events","configmaps","secrets"]}
+          status: Satisfied
+          version: v1beta1
+        - group: rbac.authorization.k8s.io
+          kind: PolicyRule
+          message: >-
+            namespaced
+            rule:{"verbs":["get"],"apiGroups":[""],"resources":["namespaces"]}
+          status: Satisfied
+          version: v1beta1
+        - group: rbac.authorization.k8s.io
+          kind: PolicyRule
+          message: >-
+            namespaced
+            rule:{"verbs":["*"],"apiGroups":["apps"],"resources":["deployments","daemonsets","replicasets","statefulsets"]}
+          status: Satisfied
+          version: v1beta1
+        - group: rbac.authorization.k8s.io
+          kind: PolicyRule
+          message: >-
+            namespaced
+            rule:{"verbs":["get","create"],"apiGroups":["monitoring.coreos.com"],"resources":["servicemonitors"]}
+          status: Satisfied
+          version: v1beta1
+        - group: rbac.authorization.k8s.io
+          kind: PolicyRule
+          message: >-
+            namespaced
+            rule:{"verbs":["*"],"apiGroups":["ember-csi.io"],"resources":["*"]}
+          status: Satisfied
+          version: v1beta1
+        - group: rbac.authorization.k8s.io
+          kind: PolicyRule
+          message: >-
+            cluster
+            rule:{"verbs":["use"],"apiGroups":["security.openshift.io"],"resources":["securitycontextconstraints"],"resourceNames":["privileged","hostmount-anyuid"]}
+          status: Satisfied
+          version: v1beta1
+        - group: rbac.authorization.k8s.io
+          kind: PolicyRule
+          message: >-
+            cluster
+            rule:{"verbs":["*"],"apiGroups":["ember-csi.io"],"resources":["*"]}
+          status: Satisfied
+          version: v1beta1
+        - group: rbac.authorization.k8s.io
+          kind: PolicyRule
+          message: >-
+            cluster
+            rule:{"verbs":["get","create","delete","patch","update"],"apiGroups":["rbac.authorization.k8s.io"],"resources":["clusterrole","clusterrolebindings","role","rolebindings","serviceaccounts"]}
+          status: Satisfied
+          version: v1beta1
+        - group: rbac.authorization.k8s.io
+          kind: PolicyRule
+          message: >-
+            cluster
+            rule:{"verbs":["list","create"],"apiGroups":["apiextensions.k8s.io"],"resources":["customresourcedefinitions"]}
+          status: Satisfied
+          version: v1beta1
+        - group: rbac.authorization.k8s.io
+          kind: PolicyRule
+          message: 'cluster rule:{"verbs":["*"],"apiGroups":[""],"resources":["nodes"]}'
+          status: Satisfied
+          version: v1beta1
+        - group: rbac.authorization.k8s.io
+          kind: PolicyRule
+          message: >-
+            cluster
+            rule:{"verbs":["get","list"],"apiGroups":[""],"resources":["secrets"]}
+          status: Satisfied
+          version: v1beta1
+        - group: rbac.authorization.k8s.io
+          kind: PolicyRule
+          message: >-
+            cluster
+            rule:{"verbs":["create","delete","list","get","watch","update"],"apiGroups":[""],"resources":["persistentvolumes"]}
+          status: Satisfied
+          version: v1beta1
+        - group: rbac.authorization.k8s.io
+          kind: PolicyRule
+          message: >-
+            cluster
+            rule:{"verbs":["get","list","watch","update"],"apiGroups":[""],"resources":["persistentvolumeclaims"]}
+          status: Satisfied
+          version: v1beta1
+        - group: rbac.authorization.k8s.io
+          kind: PolicyRule
+          message: >-
+            cluster
+            rule:{"verbs":["get","list","watch","update","delete","create"],"apiGroups":["storage.k8s.io"],"resources":["volumeattachments"]}
+          status: Satisfied
+          version: v1beta1
+        - group: rbac.authorization.k8s.io
+          kind: PolicyRule
+          message: >-
+            cluster
+            rule:{"verbs":["create","get","list","watch","update","delete"],"apiGroups":["storage.k8s.io"],"resources":["storageclasses","csinodes"]}
+          status: Satisfied
+          version: v1beta1
+        - group: rbac.authorization.k8s.io
+          kind: PolicyRule
+          message: >-
+            cluster
+            rule:{"verbs":["create","list","watch","update","delete"],"apiGroups":["*"],"resources":["events"]}
+          status: Satisfied
+          version: v1beta1
+        - group: rbac.authorization.k8s.io
+          kind: PolicyRule
+          message: >-
+            cluster
+            rule:{"verbs":["get","list","watch","create","update","delete"],"apiGroups":["snapshot.storage.k8s.io"],"resources":["volumesnapshotclasses"]}
+          status: Satisfied
+          version: v1beta1
+        - group: rbac.authorization.k8s.io
+          kind: PolicyRule
+          message: >-
+            cluster
+            rule:{"verbs":["create","get","list","watch","update","delete"],"apiGroups":["snapshot.storage.k8s.io"],"resources":["volumesnapshotcontents"]}
+          status: Satisfied
+          version: v1beta1
+        - group: rbac.authorization.k8s.io
+          kind: PolicyRule
+          message: >-
+            cluster
+            rule:{"verbs":["get","list","watch","update"],"apiGroups":["snapshot.storage.k8s.io"],"resources":["volumesnapshots"]}
+          status: Satisfied
+          version: v1beta1
+        - group: rbac.authorization.k8s.io
+          kind: PolicyRule
+          message: >-
+            cluster
+            rule:{"verbs":["create","get","list","watch","update","delete"],"apiGroups":["csi.storage.k8s.io"],"resources":["csidrivers"]}
+          status: Satisfied
+          version: v1beta1
+      group: ''
+      kind: ServiceAccount
+      message: ''
+      name: ember-csi-operator
+      status: Present
+      version: v1
+  certsLastUpdated: null
+  lastTransitionTime: '2020-03-11T17:49:12Z'
+  conditions:
+    - lastTransitionTime: '2020-03-11T17:48:47Z'
+      lastUpdateTime: '2020-03-11T17:48:47Z'
+      message: requirements not yet checked
+      phase: Pending
+      reason: RequirementsUnknown
+    - lastTransitionTime: '2020-03-11T17:48:47Z'
+      lastUpdateTime: '2020-03-11T17:48:47Z'
+      message: one or more requirements couldn't be found
+      phase: Pending
+      reason: RequirementsNotMet
+    - lastTransitionTime: '2020-03-11T17:48:48Z'
+      lastUpdateTime: '2020-03-11T17:48:48Z'
+      message: 'all requirements found, attempting install'
+      phase: InstallReady
+      reason: AllRequirementsMet
+    - lastTransitionTime: '2020-03-11T17:48:49Z'
+      lastUpdateTime: '2020-03-11T17:48:49Z'
+      message: waiting for install components to report healthy
+      phase: Installing
+      reason: InstallSucceeded
+    - lastTransitionTime: '2020-03-11T17:48:49Z'
+      lastUpdateTime: '2020-03-11T17:48:50Z'
+      message: >
+        installing: Waiting: waiting for deployment ember-csi-operator to become
+        ready: Waiting for rollout to finish: 0 of 1 updated replicas are
+        available...
+      phase: Installing
+      reason: InstallWaiting
+    - lastTransitionTime: '2020-03-11T17:49:12Z'
+      lastUpdateTime: '2020-03-11T17:49:12Z'
+      message: install strategy completed with no errors
+      phase: Succeeded
+      reason: InstallSucceeded
+  phase: Succeeded
+  certsRotateAt: null

--- a/build/olm-catalog/template.yaml
+++ b/build/olm-catalog/template.yaml
@@ -1,0 +1,345 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    containerImage: docker.io/embercsi/ember-csi-operator:latest
+    categories: "Storage"
+    capabilities: Basic Install
+    description: |-
+         Operator to deploy Ember-CSI, a multi-vendor CSI plugin driver supporting over 80 storage drivers in a single plugin to provide block and mount storage to container orchestration systems
+    certified: "false"
+    support: http://readthedocs.org/projects/ember-csi/
+    repository: https://github.com/embercsi/ember-csi-operator
+    createdAt: 2019-08-12:22:09:00
+    # BEGIN AUTO GENERATED EXAMPLES
+${SAMPLE_CONFIG}
+    # END AUTO GENERATED EXAMPLES
+  name: ember-csi-operator.v0.0.1
+  namespace: ember-csi
+spec:
+  apiservicedefinitions: {}
+  maturity: alpha
+  version: 0.0.1
+  minKubeVersion: 1.11.0
+  description: |-
+     Operator to deploy Ember-CSI, a multi-vendor CSI plugin driver supporting over 80 storage drivers in a single plugin to provide block and mount storage to container orchestration systems.
+  displayName: Ember CSI Operator
+  keywords: ['Ember-CSI', 'CSI']
+  maintainers:
+  - name: Gorka Eguileor
+    email: geguileo@redhat.com
+  - name: Christian Schwede
+    email: cschwede@redhat.com
+  - name: Kiran Thyagaraja
+    email: kthyagar@redhat.com
+  provider:
+    name: Red Hat
+  labels:
+    operated-by: ember-csi.io
+  selector:
+    matchLabels:
+      operated-by: ember-csi.io
+  links:
+  - name: Learn more about the project
+    url: http://ember-csi.io/
+  - name: Documentation
+    url: http://readthedocs.org/projects/ember-csi/
+  - name: Ember-CSI Source Code
+    url: https://github.com/embercsi/ember-csi
+  - name: Ember-CSI Operator Source Code
+    url: https://github.com/embercsi/ember-csi-operator
+  icon:
+    - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjxzdmcKICAgeG1sbnM6ZGM9Imh0dHA6Ly9wdXJsLm9yZy9kYy9lbGVtZW50cy8xLjEvIgogICB4bWxuczpjYz0iaHR0cDovL2NyZWF0aXZlY29tbW9ucy5vcmcvbnMjIgogICB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiCiAgIHhtbG5zOnN2Zz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgdmlld0JveD0iMCAwIDEwNi41NDIzMiAxMzguNzkwODUiCiAgIGhlaWdodD0iMTM4Ljc5MDg1IgogICB3aWR0aD0iMTA2LjU0MjMyIgogICB4bWw6c3BhY2U9InByZXNlcnZlIgogICBpZD0ic3ZnNDc2NiIKICAgdmVyc2lvbj0iMS4xIj48bWV0YWRhdGEKICAgICBpZD0ibWV0YWRhdGE0NzcyIj48cmRmOlJERj48Y2M6V29yawogICAgICAgICByZGY6YWJvdXQ9IiI+PGRjOmZvcm1hdD5pbWFnZS9zdmcreG1sPC9kYzpmb3JtYXQ+PGRjOnR5cGUKICAgICAgICAgICByZGY6cmVzb3VyY2U9Imh0dHA6Ly9wdXJsLm9yZy9kYy9kY21pdHlwZS9TdGlsbEltYWdlIiAvPjxkYzp0aXRsZT48L2RjOnRpdGxlPjwvY2M6V29yaz48L3JkZjpSREY+PC9tZXRhZGF0YT48ZGVmcwogICAgIGlkPSJkZWZzNDc3MCI+PGNsaXBQYXRoCiAgICAgICBpZD0iY2xpcFBhdGg0NzgyIgogICAgICAgY2xpcFBhdGhVbml0cz0idXNlclNwYWNlT25Vc2UiPjxwYXRoCiAgICAgICAgIGlkPSJwYXRoNDc4MCIKICAgICAgICAgZD0iTSAwLDE1MCBIIDMwMCBWIDAgSCAwIFoiIC8+PC9jbGlwUGF0aD48L2RlZnM+PGcKICAgICB0cmFuc2Zvcm09Im1hdHJpeCgxLjMzMzMzMzMsMCwwLC0xLjMzMzMzMzMsLTEwMS45OTEyNSwxODIuNzI5MikiCiAgICAgaWQ9Imc0Nzc0Ij48ZwogICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTMzLjU1MzI1MikiCiAgICAgICBpZD0iZzQ5MzUiPjxnCiAgICAgICAgIGlkPSJnNDc4NCIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTQyLjAwMzksNzcuNjA3OSkiPjxwYXRoCiAgICAgICAgICAgZD0ibSAwLDAgYyAyLjY1NywtMC45ODMgMy4wOTgsLTIuNjA3IDMuOTE2LC00LjMxMiAwLjgxOCwtMS43MDUgMC44ODUsLTMuNjQxIDEuMTI0LC01LjUwOCAwLjIzOCwtMS44NjYgMC43MjYsLTMuODI3IDIuMTQ0LC01LjEyMSAxLjM3OSwtMS4yNTkgMy41NTUsLTEuNjUzIDUuMzQyLC0wLjk2OCAxLjc4NywwLjY4NyAzLjA5LDIuNDE1IDMuMTk4LDQuMjQ1IDAuMTE3LDEuOTgyIC0xLjI4NCw0LjgwMSAtMi42NSw2LjI4MiBDIDkuNzE5LC0xLjc0NCA1LjA4NSwtMC4zOTkgMCwwIgogICAgICAgICAgIHN0eWxlPSJmaWxsOiNlOWFhMjk7ZmlsbC1vcGFjaXR5OjE7ZmlsbC1ydWxlOm5vbnplcm87c3Ryb2tlOm5vbmUiCiAgICAgICAgICAgaWQ9InBhdGg0Nzg2IiAvPjwvZz48ZwogICAgICAgICBpZD0iZzQ3ODgiCiAgICAgICAgIHRyYW5zZm9ybT0idHJhbnNsYXRlKDE4NS4xNDY1LDkwLjU5NTIpIj48cGF0aAogICAgICAgICAgIGQ9Im0gMCwwIGMgMy41MzMsLTYuMDk5IDUuMTQyLC0xMy4zNzQgNC43NDksLTIwLjU5NyAtMC41MiwtNy4yMDEgLTIuODkyLC0xNC40MzEgLTcuMjczLC0yMC4zNzUgLTEuMDA2LC0xLjU1MSAtMi4yODgsLTIuODgzIC0zLjQ4MiwtNC4yOTYgLTAuNjQxLC0wLjY2MyAtMS4zMzUsLTEuMjc1IC0yLjAwNSwtMS45MTQgLTAuMzQsLTAuMzE0IC0wLjY3LC0wLjYzOSAtMS4wMTksLTAuOTQyIGwgLTEuMDk3LC0wLjg1IGMgLTIuODU5LC0yLjM2NSAtNi4xNTEsLTQuMTYyIC05LjU1MiwtNS42NTMgbCAtMi42MSwtMC45OTMgYyAtMC44NzUsLTAuMzE4IC0xLjc5MywtMC41IC0yLjY5LC0wLjc1NCAtMS43ODYsLTAuNTUxIC0zLjY1MSwtMC43MTkgLTUuNDg3LC0xLjAzOCAtMy43MDIsLTAuMyAtNy40NjMsLTAuMzk4IC0xMS4xNDQsMC4yODYgbCAtMS4zODIsMC4yMTcgYyAtMC40NiwwLjA4IC0wLjkwNiwwLjIyNSAtMS4zNTksMC4zMzQgbCAtMi43MDcsMC43MTQgLTIuNjI2LDAuOTY3IGMgLTAuNDM2LDAuMTY3IC0wLjg3OCwwLjMxNyAtMS4zMDYsMC40OTkgbCAtMS4yNTgsMC42MTEgYyAtMy40MDYsMS41MjkgLTYuNDk5LDMuNjggLTkuMzIsNi4wODggbCAtMi4wMzQsMS45MDggYyAtMC42NjIsMC42NTEgLTEuMjQzLDEuMzggLTEuODY2LDIuMDY3IGwgLTAuOTE4LDEuMDQ2IGMgLTAuMjg3LDAuMzYzIC0wLjU1LDAuNzQ3IC0wLjgyNSwxLjEyIC0wLjUzOSwwLjc1NCAtMS4wOTcsMS40OTUgLTEuNjE2LDIuMjYgLTEuOTY0LDMuMTQyIC0zLjU4MSw2LjQ5OCAtNC42MTksMTAuMDQyIC0wLjk3NywzLjU0MyAtMS43MDMsNy4xODMgLTEuNjQyLDEwLjg0OCAtMC4wOTYsMy42NTEgMC4zOTcsNy4yOTggMS4zNDYsMTAuNzg5IDEuOTQyLDYuOTc0IDUuODQxLDEzLjMyNCAxMS4xMzksMTcuOTY2IC00LjQ4OCwtNS40MDkgLTcuNTY0LC0xMS44MTYgLTguNzQ2LC0xOC41MTcgLTAuNjE2LC0zLjMzNiAtMC44MjMsLTYuNzQ1IC0wLjQ2NSwtMTAuMDkxIDAuMTk5LC0zLjM1OCAxLjAwNiwtNi42MzUgMi4wNzQsLTkuNzc4IDQuNCwtMTIuNjE4IDE1Ljk1OCwtMjIuMTcyIDI4Ljk0MSwtMjQuMTYgMy4yMjMsLTAuNjQ3IDYuNTQyLC0wLjU3OSA5LjgxMiwtMC4zNjMgMS42MTcsMC4yNzUgMy4yNjgsMC4zODUgNC44NDUsMC44NjUgMC43OTEsMC4yMTggMS42MDYsMC4zNiAyLjM4LDAuNjM1IGwgMi4zMjgsMC44MTQgYyAzLjA0MywxLjIyMiA2LjAzMiwyLjcwNyA4LjY1LDQuNzQgbCAxLjAwOSwwLjcyNCBjIDAuMzIxLDAuMjYgMC42MjQsMC41NDMgMC45MzcsMC44MTQgbCAxLjg2NywxLjY0MiBjIDEuMTI5LDEuMjExIDIuMzY3LDIuMzQxIDMuMzQzLDMuNjk0IDQuMjE1LDUuMTc0IDYuODkzLDExLjU2OCA3Ljk0NywxOC4yNzcgQyAzLjMzOCwtMTMuNjE5IDIuNTI3LC02LjU2MiAwLDAiCiAgICAgICAgICAgc3R5bGU9ImZpbGw6I2UxNzUxYztmaWxsLW9wYWNpdHk6MTtmaWxsLXJ1bGU6bm9uemVybztzdHJva2U6bm9uZSIKICAgICAgICAgICBpZD0icGF0aDQ3OTAiIC8+PC9nPjxnCiAgICAgICAgIGlkPSJnNDc5MiIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTQ4LjIzNzMsNDYuNTY5MykiPjxwYXRoCiAgICAgICAgICAgZD0ibSAwLDAgYyAxLjU3MSwtMC4xNjIgMy4xNTQsLTAuMjA5IDQuNzMyLC0wLjEzIDMuMzQ0LDAuMTY3IDYuNjUsMC45MSA5LjczMywyLjIxOSAyLjMzMSwwLjk4OCA2LjI1LDIuNjcyIDcuNjMyLDQuODY1IDIuMjcsMy42MDMgMi4wODQsOS4yMSAxLjQ4MywxMy4yNTQgLTEuNDc5LDkuOTYyIC05Ljk4NCwxOC40NyAtMTkuNTQ1LDIxLjc4OSA0LjI4OSwtMS40ODggOC4zOSwtNS43MzkgMTAuNzAyLC05LjY3OSAyLjUxMywtNC4yOCAyLjUzOCwtOC43MTQgMC44MzgsLTEzLjEyIC0yLjE1OCwtNS41OTIgLTcuMTU5LC04LjgxMyAtMTMuMDk5LC04LjgxMyAtNy4xNCwwIC0xMy44NzMsNS45MTIgLTE0LjIzLDEzLjIyNyAtMC40MDIsOC4yMzkgNi41NjgsMTYuNDIxIDExLjI2OSwyMi40NzggMTMuNzc5LDE3Ljc1OCAyLjgsNDQuMzg0IDIuNzk4LDQ0LjM4NyBDIDEuNDk1LDgwLjk1MyAtMC44MjYsNzIuMDMgLTcuMDYzLDY0LjcyIC0xMi41Nyw1OC4yNjUgLTE5LjU4OCw1Mi45NzQgLTIzLjgwOCw0NS40OTMgYyAtMS45NzgsLTMuNTA2IC0zLjM1NiwtNy4zNzEgLTMuODc3LC0xMS44NzcgLTAuODQyLC03LjI2OSAwLjg5OCwtMTQuODE0IDUuMTEzLC0yMC44MjcgQyAtMTcuNDI2LDUuNDQ4IC04Ljg0MSwwLjkwNyAwLDAiCiAgICAgICAgICAgc3R5bGU9ImZpbGw6I2IxNDkyZTtmaWxsLW9wYWNpdHk6MTtmaWxsLXJ1bGU6bm9uemVybztzdHJva2U6bm9uZSIKICAgICAgICAgICBpZD0icGF0aDQ3OTQiIC8+PC9nPjxnCiAgICAgICAgIGlkPSJnNDc5NiIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTQ5LjU5NDIsNDYuNDYxOSkiPjxwYXRoCiAgICAgICAgICAgZD0ibSAwLDAgYyAwLjM5LC0wLjAyMiAwLjc3OCwtMC4wNCAxLjE2NCwtMC4wNDkgLTkuNTg2LDQuMDM1IC0xNC4zMTEsMTEuNTQ3IC0xNS4zMDIsMjAuNDI5IC0wLjUwNiw0LjU0MSAwLjkxMyw4Ljg5MSAzLjI3OSwxMi42ODMgMi4zNjQsNC44NjIgNi4xMiw5LjQwMiA5LjAxNywxMy4xMzUgMTMuNzc5LDE3Ljc1NyAyLjgsNDQuMzg0IDIuNzk5LDQ0LjM4NiBDIDAuMTM4LDgxLjA2MSAtMi4xODMsNzIuMTM4IC04LjQyLDY0LjgyNyAtMTMuOTI3LDU4LjM3MyAtMjAuOTQ1LDUzLjA4MSAtMjUuMTY1LDQ1LjYgYyAtMS45NzgsLTMuNTA2IC0zLjM1NiwtNy4zNzEgLTMuODc3LC0xMS44NzYgLTAuODQyLC03LjI3IDAuODk4LC0xNC44MTUgNS4xMTMsLTIwLjgyOCBDIC0xOC43ODMsNS41NTYgLTEwLjE5OCwxLjAxNSAtMS4zNTcsMC4xMDcgLTAuOTQ5LDAuMDY1IC0wLjU0MywwLjAzMyAtMC4xNDEsMC4wMDggLTAuMDk0LDAuMDA1IC0wLjA0NywwLjAwMyAwLDAiCiAgICAgICAgICAgc3R5bGU9ImZpbGw6I2Q3NzIzMDtmaWxsLW9wYWNpdHk6MTtmaWxsLXJ1bGU6bm9uemVybztzdHJva2U6bm9uZSIKICAgICAgICAgICBpZD0icGF0aDQ3OTgiIC8+PC9nPjxnCiAgICAgICAgIGlkPSJnNDgwMCIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTc0LjM5MjYsNTcuNDY4OCkiPjxwYXRoCiAgICAgICAgICAgZD0ibSAwLDAgYyA0LjQ5OSw1LjM3OCA1LjQ1NCwxMy45MzggNS40NDEsMTkuOTg4IC0wLjAxMiw2IC0xLjU1NywxMi4wNjEgLTUuMDM3LDE3LjI3NyAtMi44NTEsNC4yNzYgLTYuOTAxLDcuODcgLTEwLjI0LDExLjg4MSAtMy4zNCw0LjAxMiAtNi4wNDIsOC43NDggLTUuNTcsMTMuNjUxIC0yLjc5MiwtMy4wMDYgLTMuMzk0LC03LjAwNiAtMi42MTMsLTEwLjkyNCAwLjY4MywtMy40MjIgMi41MzcsLTYuNTczIDMuNzY4LC05Ljg0NCAwLjkxNywtMi40MzkgMS45MTUsLTQuODY2IDIuNDQ3LC03LjQyNiAwLjU4NSwtMi44MTYgMC4yOTMsLTUuMDQ1IC0wLjc1NSwtNy42NzkgMS41ODYsLTEuMzczIDMuMTYzLC0yLjk3NiA0LjI5NiwtNC43NTMgMS4xMzUsLTEuNzc3IDEuMzk4LC0zLjk1NCAyLjM5MiwtNS44MDQgMi4yNjYsLTQuMjIgMy4wMzcsLTkuMTE4IDIuNTQ2LC0xMy44OTgiCiAgICAgICAgICAgc3R5bGU9ImZpbGw6I2UwYTgzMjtmaWxsLW9wYWNpdHk6MTtmaWxsLXJ1bGU6bm9uemVybztzdHJva2U6bm9uZSIKICAgICAgICAgICBpZD0icGF0aDQ4MDIiIC8+PC9nPjxnCiAgICAgICAgIGlkPSJnNDgwNCIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTYyLjc5OTgsMTAyLjU3MjMpIj48cGF0aAogICAgICAgICAgIGQ9Ik0gMCwwIEMgLTMuMjI5LDQuNjc4IC02LjkwOCwxMi4wMjggLTMuODEzLDE3LjY5NCAtNi42MDUsMTQuNjg4IC03LjIwNywxMC42ODcgLTYuNDI2LDYuNzcgYyAwLjY4MywtMy40MjMgMi41MzYsLTYuNTc0IDMuNzY4LC05Ljg0NSAwLjkxNywtMi40MzggMS45MTUsLTQuODY2IDIuNDQ3LC03LjQyNSAwLjU4NSwtMi44MTcgMC4yOTMsLTUuMDQ2IC0wLjc1NSwtNy42NzkgMS41ODYsLTEuMzc0IDMuMTYyLC0yLjk3NiA0LjI5NiwtNC43NTMgMS4xMzUsLTEuNzc4IDEuMzk4LC0zLjk1NCAyLjM5MiwtNS44MDQgMC4yMjEsLTAuNDEzIDAuNDI0LC0wLjgzNSAwLjYxOCwtMS4yNiBsIDEuMDcsLTAuMDYyIGMgMCwwIDIuMjc1LDcuOTYyIDEuMjcyLDE1LjE4MiBDIDcuODcsLTkuMDQzIDMuMjA2LC00LjY0NSAwLDAiCiAgICAgICAgICAgc3R5bGU9ImZpbGw6I2MzNTAyZTtmaWxsLW9wYWNpdHk6MTtmaWxsLXJ1bGU6bm9uemVybztzdHJva2U6bm9uZSIKICAgICAgICAgICBpZD0icGF0aDQ4MDYiIC8+PC9nPjxnCiAgICAgICAgIGlkPSJnNDgwOCIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTUwLjc1ODMsNDYuNDEzMSkiPjxwYXRoCiAgICAgICAgICAgZD0ibSAwLDAgYyAwLDAgMTQuMTcsMy42OTEgMTYuNjY5LDE4Ljc5MyAyLjE4NiwxMy4yMDUgLTkuMTM3LDIxLjE4MyAtMTUuMTU1LDIzLjM2IDAsMCAxMy4xNzgsMC44OTggMjAuMTIxLC02Ljg0OSBDIDI4LjU3OSwyNy41NTggMjguMTEsMTkuMDg2IDI0LjI4OCwxMi4wNzEgMjAuMjIxLDQuNjA4IDkuMDE5LC0wLjY4MiAwLDAiCiAgICAgICAgICAgc3R5bGU9ImZpbGw6I2Q3NzIzMDtmaWxsLW9wYWNpdHk6MTtmaWxsLXJ1bGU6bm9uemVybztzdHJva2U6bm9uZSIKICAgICAgICAgICBpZD0icGF0aDQ4MTAiIC8+PC9nPjxnCiAgICAgICAgIGlkPSJnNDgxMiIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTUwLjc1ODMsNDYuNDEzMSkiPjxwYXRoCiAgICAgICAgICAgZD0iTSAwLDAgQyAxNS42MTcsMS4zMyAyMy45ODksMTQuMDQxIDIxLjQ1MywyNi4yNDEgMTkuMDc1LDM3LjY3NyAxLjUxNCw0Mi4xNTMgMS41MTQsNDIuMTUzIDcuNTMyLDM5Ljk3NiAxOC44NTUsMzEuOTk4IDE2LjY2OSwxOC43OTMgMTQuMTcsMy42OTEgMCwwIDAsMCIKICAgICAgICAgICBzdHlsZT0iZmlsbDojZTBhODMyO2ZpbGwtb3BhY2l0eToxO2ZpbGwtcnVsZTpub256ZXJvO3N0cm9rZTpub25lIgogICAgICAgICAgIGlkPSJwYXRoNDgxNCIgLz48L2c+PGcKICAgICAgICAgaWQ9Imc0ODE2IgogICAgICAgICB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxMjcuNTkxMyw3Ni45MjI5KSI+PHBhdGgKICAgICAgICAgICBkPSJtIDAsMCBjIDEuMDk0LDkuMjEzIDcuMTk4LDE1LjYzIDEyLjk5LDIyLjQwMiA0LjgyMiw1LjYzOCA5LjA1NiwxMS45NTUgMTAuNTkzLDE5LjMxMyAxLjIzOCw1LjkzNSAxLjMsMTIuNTkgLTAuNjI0LDE4LjQwOSBDIDIyLjE0MSw1MC42IDE5LjgyLDQxLjY3NyAxMy41ODMsMzQuMzY2IDguMDc2LDI3LjkxMiAxLjA1OCwyMi42MiAtMy4xNjIsMTUuMTM5IC01LjE0LDExLjYzMyAtNi41MTgsNy43NjggLTcuMDM5LDMuMjYzIGMgLTAuODQyLC03LjI3IDAuODk4LC0xNC44MTUgNS4xMTMsLTIwLjgyNyA1LjE0NiwtNy4zNDEgMTMuNzMxLC0xMS44ODIgMjIuNTcyLC0xMi43OSAwLjQwOCwtMC4wNDIgMC44MTMsLTAuMDc0IDEuMjE2LC0wLjA5OSAwLjA0NywtMC4wMDMgMC4wOTQsLTAuMDA1IDAuMTQxLC0wLjAwOCAwLjM5LC0wLjAyMiAwLjc3OCwtMC4wNCAxLjE2NCwtMC4wNDkgLTYuNDU0LDAuODgzIC0xMi4yNTQsMy4xMjggLTE2LjQ2MSw3LjQ3IEMgMC45NTQsLTE3LjEwMyAtMC45NTEsLTguMDEgMCwwIgogICAgICAgICAgIHN0eWxlPSJmaWxsOiNlMGE4MzI7ZmlsbC1vcGFjaXR5OjE7ZmlsbC1ydWxlOm5vbnplcm87c3Ryb2tlOm5vbmUiCiAgICAgICAgICAgaWQ9InBhdGg0ODE4IiAvPjwvZz48L2c+PC9nPjwvc3ZnPg==
+      mediatype: image/svg+xml
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: true
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+      - serviceAccountName: ember-csi-operator
+        rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - ember-csi.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+
+      clusterPermissions:
+      - serviceAccountName: ember-csi-operator
+        rules:
+        - apiGroups:
+          - "security.openshift.io"
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+          resourceNames:
+          - privileged
+          - hostmount-anyuid
+        - apiGroups:
+          - ember-csi.io
+          resources:
+          - "*"
+          verbs:
+          - "*"
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrole
+          - clusterrolebindings
+          - role
+          - rolebindings
+          - serviceaccounts
+          verbs:
+          - get
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - list
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumes
+          verbs:
+          - create
+          - delete
+          - list
+          - get
+          - watch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - volumeattachments
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+          - delete
+          - create
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          - csinodes
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+          - delete
+        - apiGroups:
+          - "*"
+          resources:
+          - events
+          verbs:
+          - create
+          - list
+          - watch
+          - update
+          - delete
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - volumesnapshotclasses
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - volumesnapshotcontents
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+          - delete
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - volumesnapshots
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+        - apiGroups:
+          - csi.storage.k8s.io
+          resources:
+          - csidrivers
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+          - delete
+      deployments:
+      - name: ember-csi-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: ember-csi-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: ember-csi-operator
+            spec:
+              containers:
+              - command:
+                - ember-csi-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: ember-csi-operator
+                image: docker.io/embercsi/ember-csi-operator:latest
+                imagePullPolicy: Always
+                name: ember-csi-operator
+                ports:
+                - containerPort: 60000
+                  name: metrics
+                readinessProbe:
+                  exec:
+                    command:
+                    - stat
+                    - /tmp/operator-sdk-ready
+                  failureThreshold: 1
+                  initialDelaySeconds: 4
+                  periodSeconds: 10
+                resources: {}
+              serviceAccountName: ember-csi-operator
+
+  customresourcedefinitions:
+    owned:
+    - kind: EmberCSI
+      name: embercsis.ember-csi.io
+      version: v1alpha1
+      displayName: Deployments
+      description: Represents a deployment of EmberCSI driver
+      resources:
+      - kind: StorageClass
+        name: ''
+        version: v1
+      - kind: StatefulSet
+        name: ''
+        version: v1
+      - kind: EmberCSI
+        name: ''
+        version: v1alpha
+      - kind: Daemonset
+        name: ''
+        version: v1
+      statusDescriptors:
+        - description: The installed Ember CSI version
+          displayName: Version
+          path: version
+      specDescriptors:
+        - description: Define which Nodes the Pods are scheduled on.
+          displayName: nodeSelect
+          path: nodeSelector
+        - description: Ember CSI driver container image to use
+          displayName: image
+          path: image
+        - description: Config for Ember
+          displayName: config
+          path: config
+        - description: Tolerations
+          displayName: tolerations
+          path: tolerations
+        - description: Topologies
+          displayName: topologies
+          path: topologies
+        # BEGIN AUTO GENERATED CONFIGURATION OPTIONS
+${DRIVER_OPTIONS}
+        # END AUTO GENERATED CONFIGURATION OPTIONS

--- a/build/olm-catalog/yaml-options-gen.py
+++ b/build/olm-catalog/yaml-options-gen.py
@@ -1,0 +1,662 @@
+#!/bin/env python
+# Takes input from command: ember-list-drivers -d
+# Use CONSOLE_VERSION to define the console version that will be used, because
+# available features depend on it
+# Use DEVELOPMENT env variable to say we want to use the template-dev.yaml file
+import collections
+import copy
+import itertools
+import json
+import re
+import os
+import sys
+
+
+# We don't support NFS drivers right now
+EXCLUDE_DRIVERS = ['.*?nfs.*?']
+INCLUDE_DRIVERS = None
+
+DEVELOPMENT = bool(int(os.environ.get('DEVELOPMENT', 0) or 0))
+ADDITIONAL_SPACES = 2 if DEVELOPMENT else 0
+
+# v1,v2,v3
+TRANSFORM_LIST_OF_STRINGS = '__transform_csv'
+# k1:v1,k2:v2
+TRANSFORM_DICT_OF_STRING = '__transform_csv_kvs'
+# Empty string means None
+TRANSFORM_POSSIBLE_NONE = '__transform_empty_none'
+
+MISSING_OPTIONS = (
+    {"default": "$my_ip",
+     "deprecated_for_removal": "False",
+     "help": "The IP address that the iSCSI daemon is listening on",
+     "name": "target_ip_address",
+     "required": "False",
+     "secret": "False",
+     "type": "String"},
+    {"default": "admin",
+     "deprecated_for_removal": "False",
+     "help": "Username for SAN controller",
+     "name": "san_login",
+     "required": "True",
+     "secret": "False",
+     "type": "String"},
+    {"default": "",
+     "deprecated_for_removal": "False",
+     "help": "Password for SAN controller",
+     "name": "san_password",
+     "required": "True",
+     "secret": "True",
+     "type": "String"},
+    {"default": "",
+     "deprecated_for_removal": "False",
+     "help": "IP address of SAN controller",
+     "name": "san_ip",
+     "required": "True",
+     "secret": "False",
+     "type": "String"},
+    # target_protocol is defined in MacroSAN FC and ICSCI, but just in case
+    {"default": "iscsi",
+     "deprecated_for_removal": "False",
+     "help": "Determines the target protocol for new volumes, created with "
+             "tgtadm, lioadm and nvmet target helpers. In order to enable "
+             "RDMA, this parameter should be set with the value \"iser\". The "
+             "supported iSCSI protocol values are \"iscsi\" and \"iser\", in "
+             "case of nvmet target set to \"nvmet_rdma\".",
+     "name": "target_protocol",
+     "required": "False",
+     "secret": "False",
+     "type": "String(choices=['iscsi', 'iser', 'nvmet_rdma'])"},
+    # target_protocol is defined in MacroSAN FC and iCSCI, but just in case
+    {"default": "tgtadm",
+     "deprecated_for_removal": "False",
+     "help": "Target user-land tool to use. tgtadm is default, use lioadm for "
+             "LIO iSCSI support, scstadmin for SCST target support, ietadm "
+             "for iSCSI Enterprise Target, iscsictl for Chelsio iSCSI Target, "
+             "nvmet for NVMEoF support, spdk-nvmeof for SPDK NVMe-oF, or fake "
+             "for testing.",
+     "name": "target_helper",
+     "required": "False",
+     "secret": "False",
+     "type": "String(choices=['tgtadm', 'lioadm', 'scstadmin', 'iscsictl', "
+             "'ietadm', 'nvmet', 'spdk-nvmeof', 'fake'])"},
+    {"default": "False",
+     "deprecated_for_removal": "False",
+     "help": "Tell driver to use SSL for connection to backend storage if the "
+             "driver supports it.",
+     "name": "driver_use_ssl",
+     "required": "False",
+     "secret": "False",
+     "type": "Boolean"},
+    {"default": "22",
+     "deprecated_for_removal": "False",
+     "help": "SSH port to use with SAN",
+     "name": "san_ssh_port",
+     "required": "False",
+     "secret": "False",
+     "type": "Port"},
+    {"default": "30",
+     "deprecated_for_removal": "False",
+     "help": "SSH connection timeout in seconds",
+     "name": "ssh_conn_timeout",
+     "required": "False",
+     "secret": "False",
+     "type": "Integer"},
+    {"default": "",
+     "deprecated_for_removal": "False",
+     "help": "Filename of private key to use for SSH authentication",
+     "name": "san_private_key",
+     "required": "False",
+     "secret": "False",
+     "type": "String"},
+    {"default": "1",
+     "deprecated_for_removal": "False",
+     "help": "The port that the NVMe target is listening on.",
+     "name": "nvmet_port_id",
+     "required": "False",
+     "secret": "False",
+     "type": "Port"},
+    {"default": "",
+     "deprecated_for_removal": "False",
+     "help": "Certain ISCSI targets have predefined target names, SCST target "
+             "driver uses this name.",
+     "name": "scst_target_iqn_name",
+     "required": "False",
+     "secret": "False",
+     "type": "String"},
+    {"default": "iscsi",
+     "deprecated_for_removal": "False",
+     "help": "SCST target implementation can choose from multiple SCST target "
+             "drivers.",
+     "name": "scst_target_driver",
+     "required": "False",
+     "secret": "False",
+     "type": "String"},
+    {"default": "",
+     "deprecated_for_removal": "False",
+     "help": "The NVMe target remote configuration IP address.",
+     "name": "spdk_rpc_ip",
+     "required": "False",
+     "secret": "False",
+     "type": "String"},
+    {"default": "8000",
+     "deprecated_for_removal": "False",
+     "help": "The NVMe target remote configuration port.",
+     "name": "spdk_rpc_port",
+     "required": "False",
+     "secret": "False",
+     "type": "Port"},
+    {"default": "",
+     "deprecated_for_removal": "False",
+     "help": "The NVMe target remote configuration username.",
+     "name": "spdk_rpc_username",
+     "required": "False",
+     "secret": "False",
+     "type": "String"},
+    {"default": "",
+     "deprecated_for_removal": "False",
+     "help": "The NVMe target remote configuration password.",
+     "name": "spdk_rpc_password",
+     "required": "False",
+     "secret": "True",
+     "type": "String"},
+    {"default": "64",
+     "deprecated_for_removal": "False",
+     "help": "Queue depth for rdma transport.",
+     "name": "spdk_max_queue_depth",
+     "required": "False",
+     "secret": "True",
+     "type": "Integer(min=1, max=128)"},
+)
+
+MISSING_DRIVER_OPTIONS = {
+    'QnapISCSI': ('target_ip_address', 'san_login', 'san_password',
+                  'use_chap_auth', 'chap_username', 'chap_password',
+                  'driver_ssl_cert_verify'),
+    'XtremIOISCSI': ('san_ip', 'san_login', 'san_password',
+                     'driver_ssl_cert_verify', 'driver_ssl_cert_path'),
+    'XtremIOFC': ('san_ip', 'san_login', 'san_password',
+                  'driver_ssl_cert_verify', 'driver_ssl_cert_path'),
+    'LVMVolume': ('target_ip_address', 'target_helper', 'target_protocol',
+                  'volume_clear', 'volume_clear_size', 'volume_dd_blocksize',
+                  'target_prefix', 'volumes_dir', 'target_port',
+                  'iscsi_secondary_ip_addresses',
+                  'iscsi_write_cache', 'iscsi_target_flags',  # TGT
+                  'iet_conf', 'iscsi_iotype',  # IET
+                  'nvmet_port_id',  # NVMET
+                  'scst_target_iqn_name', 'scst_target_driver',  # SCST
+                  'spdk_rpc_ip', 'spdk_rpc_port', 'spdk_rpc_username',  # SPDK
+                  'spdk_rpc_password', 'spdk_max_queue_depth',  # SPDK
+                  ),
+    'HPE3PARISCSI': ('san_ip', 'san_login', 'san_password', 'target_port',
+                     'san_ssh_port', 'ssh_conn_timeout', 'san_private_key',
+                     'target_ip_address'),
+    'HPE3PARFC': ('san_ip', 'san_login', 'san_password', 'target_port',
+                  'san_ssh_port', 'ssh_conn_timeout', 'san_private_key',
+                  'target_ip_address'),
+    'KaminarioISCSI': ('san_ip', 'san_login', 'san_password',
+                       'volume_dd_blocksize'),
+    'PowerMaxFC': ('san_ip', 'san_login', 'san_password',
+                   'driver_ssl_cert_verify'),
+    'PowerMaxISCSI': ('san_ip', 'san_login', 'san_password',
+                      'driver_ssl_cert_verify', 'use_chap_auth',
+                      'chap_username', 'chap_password'),
+    'SynoISCSI': ('target_ip_address', 'target_protocol', 'driver_use_ssl',
+                  'use_chap_auth', 'iscsi_secondary_ip_addresses',
+                  'target_port', 'chap_username', 'chap_password',
+                  'target_prefix'),
+    'PureISCSI': ('san_ip', 'driver_ssl_cert_verify', 'driver_ssl_cert_path',
+                  'use_chap_auth'),
+    'PureFC': ('san_ip', 'driver_ssl_cert_verify', 'driver_ssl_cert_path',
+               'use_chap_auth'),
+    'SolidFire': ('san_ip', 'san_login', 'san_password',
+                  'driver_ssl_cert_verify'),
+}
+
+IGNORE_OPTIONS = ['max_over_subscription_ratio',
+                  'reserved_percentage',
+                  'use_multipath_for_image_xfer',
+                  'xtremio_volumes_per_glance_cache',
+                  'auto_calc_max_oversubscription_ratio',
+                  'replication_device',
+                  'replication_connect_timeout',
+                  ]
+
+CONSOLE_VERSION = os.environ.get('CONSOLE_VERSION', '').strip() or '4.0'
+CONSOLE_VERSION_TUPLE = list(map(int, (CONSOLE_VERSION + '.0').split('.')[:2]))
+USE_GROUPS = CONSOLE_VERSION_TUPLE < [4, 4]
+
+DROPDOWN_TEMPLATE = """        - description: The type of storage backend
+          displayName: Driver
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:DriverSettings'
+${DROPDOWN_OPTIONS}"""
+SAMPLE_TEMPLATE = collections.OrderedDict([
+    ("apiVersion", "ember-csi.io/v1alpha1"),
+    ("kind", "EmberCSI"),
+    ("metadata", {"name": "example"}),
+    ("spec", {
+        "config": collections.OrderedDict([
+            ("envVars", collections.OrderedDict([
+                ("X_CSI_PERSISTENCE_CONFIG", {"storage": "crd"}),
+                # TODO: Operator to support X_CSI_ABORT_DUPLICATES as a boolean
+                # and convert it to string form Ember-CSI
+                # ("X_CSI_ABORT_DUPLICATES", False),
+                ("X_CSI_DEBUG_MODE", ""),
+                ("X_CSI_DEFAULT_MOUNT_FS", "ext4"),
+                ("X_CSI_EMBER_CONFIG", {"plugin_name": "",
+                                        "grpc_workers": 30,
+                                        "slow_operations": True,
+                                        "enable_probe": False,
+                                        "disabled": "[]",
+                                        "project_id": "ember_csi.io",
+                                        "user_id": "ember_csi.io",
+                                        "disable_logs": False,
+                                        "debug": False,
+                                        })])),
+            ("sysFiles", {
+                "name": "",
+                "key": ""
+            })
+        ])
+    })
+])
+
+
+class Option(object):
+    UI_PREFIX = "'urn:alm:descriptor:com.tectonic.ui:"
+
+    def _set_default(self, option):
+        self.default = '' if option['default'] == 'None' else option['default']
+
+    def __init__(self, option):
+        self.drivers = set()
+        self.name = option['name']
+        self.display_name = option['name'].replace('_', ' ').title()
+        self.help = option['help'].replace('\n', '.').replace('"', "'").title()
+        self.ignore = (option['deprecated_for_removal'] == 'True' or
+                       option['name'] in IGNORE_OPTIONS)
+
+        if option.get('secret') == 'True':
+            self.form_type = self.UI_PREFIX + "password'"
+            self._set_default(option)
+
+        elif option['type'].startswith('String(choices='):
+            start = option['type'].index('[') + 1
+            end = option['type'].index(']')
+
+            raw_choices = [c.strip()
+                           for c in option['type'][start:end].split(',')]
+
+            # Tell the operator if we have the None instance option (different
+            # from 'none')
+            if 'None' in raw_choices:
+                # If we have multiple ways to say None, we leave the string
+                # name
+                if "'none'" in raw_choices:
+                    raw_choices.remove('None')
+                else:
+                    self.name += TRANSFORM_POSSIBLE_NONE
+
+            choices = ['' if c == 'None' else c.replace("'", '')
+                       for c in raw_choices]
+            self._set_default(option)
+            prefix = self.UI_PREFIX + 'select:'
+            self.form_type = prefix + ("'\n            - " + prefix).join(
+                c.strip() for c in choices) + "'"
+
+        # We don't have URI, IPAddress or Float types in the UI
+        elif (option['type'].startswith('String')
+              or option['type'] in ('URI', 'Float', 'IPAddress')):
+            self.form_type = self.UI_PREFIX + "text'"
+            self._set_default(option)
+            if '(' in option['type']:
+                self.help += ' ' + option['type'][option['type'].index('('):]
+
+        # booleanSwitch looks better, but it doesn't work for duplicated items
+        elif option['type'] == 'Boolean':
+            self.form_type = self.UI_PREFIX + "checkbox'"
+            self.default = option['default'] == 'True'
+
+        elif (option['type'].startswith('Port') or
+              option['type'].startswith('Integer')):
+            self.form_type = self.UI_PREFIX + "number'"
+            self.default = ('' if option['default'] == 'None'
+                            else int(float(option['default'])))
+
+            # If we have min and max defined, add it to the help
+            if '(' in option['type']:
+                self.help += ' ' + option['type'][option['type'].index('('):]
+
+        elif option['type'] == 'Dict of String':
+            self.form_type = self.UI_PREFIX + "text'"
+            # Tell the operator that this needs to be transformed
+            self.name += TRANSFORM_DICT_OF_STRING
+
+            default = option['default']
+            if default in ('None', ''):
+                self.default = ''
+            else:
+                default = json.loads(default.replace("'", '"'))
+                self.default = ','.join('%s:%s' % i for i in default.items())
+
+            self.help += ' [ie: k1:v1,k2:v2]'
+
+        elif option['type'] in ('List of String', 'List of IPAddress'):
+            self.form_type = self.UI_PREFIX + "text'"
+            # Tell the operator that this needs to be transformed
+            self.name += TRANSFORM_LIST_OF_STRINGS
+            self.help += ' [ie: v1,v2]'
+            # Convert the default (ie: ['Pool0']) into a CSV
+            default = option['default']
+            if default in ('None', ''):
+                self.default = ''
+            else:
+                default_list = json.loads(default.replace("'", '"'))
+                self.default = ','.join(default_list)
+
+        else:
+            raise Exception('Unkown type %s' % option['type'])
+
+        # Optional depends on the driver, so don't indicate anything
+        # if option['required'] == 'True':
+        #     self.help += ' [Optional]'
+
+    def add_driver(self, driver):
+        self.drivers.add(driver)
+
+
+def include_driver(drivername):
+    if EXCLUDE_DRIVERS is not None:
+        for regex in EXCLUDE_DRIVERS:
+            if re.match(regex, drivername, re.IGNORECASE):
+                return False
+
+    if INCLUDE_DRIVERS is None:
+        return True
+
+    for regex in INCLUDE_DRIVERS:
+        if re.match(regex, drivername, re.IGNORECASE):
+            return True
+
+    return False
+
+
+def render_option(option, driver, group_options=False):
+    if option.ignore:
+        return ''
+    group = driver + "Options" if group_options else 'DriverSettings'
+
+    result = """
+        - description: {description}
+          displayName: {display_name}
+          path: config.envVars.X_CSI_BACKEND_CONFIG.{name}
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:{group}'
+            - {opt_type}
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:{driver}'
+    """.format(name=option.name,  # noqa
+               display_name=option.display_name,
+               description='"' + option.help + '"',
+               opt_type=option.form_type,
+               driver=driver,
+               group=group)
+
+    # The only way to present the groups folded is to set them as advanced
+    if group_options:
+        result += 8 * ' ' + "- 'urn:alm:descriptor:com.tectonic.ui:advanced'"
+    # We don't indent here, it's the caller's responsibility
+    return result
+
+
+def additional_options():
+    """Options that are generic for all drivers."""
+    # TODO: Operator to support a JSON string for the X_CSI_PERSISTENCE_CONFIG
+    # TODO: Operator to support X_CSI_ABORT_DUPLICATES as a boolean and convert
+    #       it to string form Ember-CSI
+    return """
+        - description: Backend name (set by operator if empty)
+          displayName: Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: The unique name of the plugin (set by operator if empty)
+          displayName: Plugin name
+          path: config.envVars.X_CSI_EMBER_CONFIG.plugin_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: Number of gRPC workers for the CSI plugin
+          displayName: gRPC workers
+          path: config.envVars.X_CSI_EMBER_CONFIG.grpc_workers
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: Allow keepalive pings when there are no gRPC calls
+          displayName: Slow operations
+          path: config.envVars.X_CSI_EMBER_CONFIG.slow_operations
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: Get stats from the storage backend when the CSI plugin is probed
+          displayName: Probe backend
+          path: config.envVars.X_CSI_EMBER_CONFIG.enable_probe
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: > List of features we want to disable on the plugin.
+            Features that can be disabled are clone, snapshot, expand,
+            expand_online. Must be a JSON list ie: ["clone", "expand_online"]'
+          displayName: Disabled features
+          path: config.envVars.X_CSI_EMBER_CONFIG.disabled__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: Project ID to store in the persistence metadata backend
+          displayName: Project ID
+          path: config.envVars.X_CSI_EMBER_CONFIG.project_id
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: User ID to store in the persistence metadata backend
+          displayName: User ID
+          path: config.envVars.X_CSI_EMBER_CONFIG.user_id
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: Disable all the logs in the CSI plugins
+          displayName: Quiet
+          path: config.envVars.X_CSI_EMBER_CONFIG.disable_logs
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: Enabled debug log levels (quiet option must not be set)
+          displayName: Debug logs
+          path: config.envVars.X_CSI_EMBER_CONFIG.debug
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        # - description: If we want to abort or queue (default) duplicated requests.
+        #   displayName: Abort duplicates
+        #   path: config.envVars.X_CSI_ABORT_DUPLICATES
+        #   x-descriptors:
+        #     - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+        #     - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        #     - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: Enable remote debugging with rpdb on calls
+          displayName: Remote debugging
+          path: config.envVars.X_CSI_DEBUG_MODE
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:RPDB'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: Default filesystem for mount type volumes when it is not specified
+          displayName: Default filesystem
+          path: config.envVars.X_CSI_DEFAULT_MOUNT_FS
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:btrfs'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:cramfs'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:ext2'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:ext3'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:ext4'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:minix'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:xfs'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        # - description: Metadata persistence plugin selection and settings (must be valid JSON)
+        #   displayName: Persistence
+        #   path: config.envVars.X_CSI_PERSISTENCE_CONFIG
+        #   x-descriptors:
+        #     - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+        #     - 'urn:alm:descriptor:com.tectonic.ui:text'
+        #     - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: Allow unsupported drivers to run
+          displayName: Unsupported
+          path: config.envVars.X_CSI_BACKEND_CONFIG.enable_unsupported_driver
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: sysFiles secrets
+          displayName: sysFiles secrets
+          path: config.sysFiles.key
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:io.kubernetes:Secret'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: sysFiles secrets
+          displayName: sysFiles secrets name
+          path: config.sysFiles.name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: Use multipath if driver supports it
+          displayName: Multipath
+          path: config.X_CSI_BACKEND_CONFIG.multipath
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:DriverSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'"""  # noqa
+
+
+def _indent(text, spaces):
+    if not spaces:
+        return text
+
+    padding = ' ' * spaces
+    return padding + padding.join(line for line in text.splitlines(True))
+
+
+def generate_driver_options(original_drivers, options):
+    # For some reason the form presents it reversed
+    names = sorted(original_drivers.keys(), reverse=True)
+    option_element = 12 * ' ' + "- 'urn:alm:descriptor:com.tectonic.ui:select:"
+    dropdown_options = "\n".join(option_element + key + "'" for key in names)
+
+    dropdown = DROPDOWN_TEMPLATE.replace('${DROPDOWN_OPTIONS}',
+                                         dropdown_options)
+
+    rendered_opts = []
+    # But the groups need to go in the right order
+    for name in sorted(names):
+        rendered_opts.extend(render_option(options[o], name, USE_GROUPS)
+                             for o in original_drivers[name])
+
+    driver_options = dropdown + ''.join(rendered_opts) + additional_options()
+    return _indent(driver_options, ADDITIONAL_SPACES)
+
+
+def generate_sample_options(name, option_names, options):
+    cfg = collections.OrderedDict(name='', enable_unsupported_driver=False,
+                                  driver=name)
+    cfg.update((k, options[k].default)
+               for k in option_names
+               if not options[k].ignore)
+    sample = copy.deepcopy(SAMPLE_TEMPLATE)
+    sample['spec']['config']['envVars']['X_CSI_BACKEND_CONFIG'] = cfg
+    return sample
+
+
+def generate_sample_config(original_drivers, options):
+    """Generate the whole alm-examples section."""
+    # TODO: Ember-CSI will complain about a bunch of unknown configuration
+    # options, since we'll pass ALL the existing configuration options.  Find a
+    # way for the Operator to only pass relevant config options.
+    # Generate individual examples with the defaults for each backend
+    samples = [
+        generate_sample_options(name, sorted(original_drivers[name]), options)
+        for name in sorted(original_drivers.keys())
+    ]
+    used_options = sorted(set(itertools.chain.from_iterable(
+        original_drivers[name] for name in original_drivers.keys())
+    ))
+    # We generate a sample with all the options and the first driver name
+    defaults = generate_sample_options(sorted(original_drivers.keys())[0],
+                                       used_options, options)
+    # The first examples is used  for the defaults of the form.
+    samples.insert(0, defaults)
+
+    result = json.dumps(samples, indent=2)
+    # We need to indent it
+    examples = _indent(result, 6)
+    res = '    alm-examples: |-\n' + examples
+    # Remove trailing spaces introduced by JSON
+    return '\n'.join(line.rstrip() for line in res.splitlines())
+
+
+def add_missing_config_options(backends, options):
+    for option_data in MISSING_OPTIONS:
+        options.setdefault(option_data['name'], Option(option_data))
+
+    for driver_name, option_names in MISSING_DRIVER_OPTIONS.items():
+        if driver_name in backends:
+            backends[driver_name].update(option_names)
+            for option_name in option_names:
+                options[option_name].add_driver(driver_name)
+
+
+def parse_ember_data(data):
+    result_drivers = {}
+    result_options = {}
+
+    for driver_name, v in data.items():
+        driver_options = {o['name']: Option(o) for o in v['driver_options']}
+        result_drivers[driver_name] = set(driver_options.keys())
+        for option_name, option in driver_options.items():
+            option = result_options.setdefault(option_name, option)
+            option.add_driver(driver_name)
+    return result_drivers, result_options
+
+
+if __name__ == '__main__':
+    data = json.load(sys.stdin)
+
+    original_drivers, options = parse_ember_data(data)
+    # Exclude drivers we don't support, like NFS
+    backends = {k: v for k, v in original_drivers.items() if include_driver(k)}
+
+    # Some drivers are not reporting all their options, fix the ones we know
+    add_missing_config_options(backends, options)
+
+    driver_options = generate_driver_options(backends, options)
+    sample_config = generate_sample_config(backends, options)
+
+    template_name = 'template-dev.yaml' if DEVELOPMENT else 'template.yaml'
+    with open(template_name, 'r') as f:
+        template = f.read()
+    result = template.replace('${DRIVER_OPTIONS}', driver_options)
+    result = result.replace('${SAMPLE_CONFIG}', sample_config)
+    print(result)

--- a/deploy/olm-catalog/next/ember-csi-operator.vX.Y.Z.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/next/ember-csi-operator.vX.Y.Z.clusterserviceversion.yaml
@@ -1,0 +1,9205 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    containerImage: docker.io/embercsi/ember-csi-operator:latest
+    categories: "Storage"
+    capabilities: Basic Install
+    description: |-
+         Operator to deploy Ember-CSI, a multi-vendor CSI plugin driver supporting over 80 storage drivers in a single plugin to provide block and mount storage to container orchestration systems
+    certified: "false"
+    support: http://readthedocs.org/projects/ember-csi/
+    repository: https://github.com/embercsi/ember-csi-operator
+    createdAt: 2019-08-12:22:09:00
+    # BEGIN AUTO GENERATED EXAMPLES
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "ACCESSIscsi",
+                  "name": "",
+                  "as13000_ipsan_pools": "Pool0",
+                  "as13000_meta_pool": "",
+                  "as13000_token_available_time": 3300,
+                  "backend_availability_zone": "",
+                  "chap": "disabled",
+                  "chap_password": "",
+                  "chap_username": "",
+                  "chiscsi_conf": "/etc/chelsio-iscsi/chiscsi.conf",
+                  "cinder_eternus_config_file": "/etc/cinder/cinder_fujitsu_eternus_dx.xml",
+                  "cinder_huawei_conf_file": "/etc/cinder/cinder_huawei_conf.xml",
+                  "connection_type": "iscsi",
+                  "cycle_period_seconds": 300,
+                  "default_timeout": 31536000,
+                  "deferred_deletion_delay": 0,
+                  "deferred_deletion_purge_interval": 60,
+                  "dell_api_async_rest_timeout": 15,
+                  "dell_api_sync_rest_timeout": 30,
+                  "dell_sc_api_port": 3033,
+                  "dell_sc_server_folder": "openstack",
+                  "dell_sc_ssn": 64702,
+                  "dell_sc_verify_cert": false,
+                  "dell_sc_volume_folder": "openstack",
+                  "dell_server_os": "Red Hat Linux 6.x",
+                  "destroy_empty_storage_group": false,
+                  "disable_discovery": false,
+                  "driver_client_cert": "",
+                  "driver_client_cert_key": "",
+                  "driver_data_namespace": "",
+                  "driver_ssl_cert_path": "",
+                  "driver_ssl_cert_verify": false,
+                  "driver_use_ssl": false,
+                  "enable_deferred_deletion": false,
+                  "eqlx_cli_max_retries": 5,
+                  "eqlx_group_name": "group-0",
+                  "eqlx_pool": "default",
+                  "excluded_domain_ips": "",
+                  "filter_function": "",
+                  "flashsystem_connection_protocol": "FC",
+                  "flashsystem_multihostmap_enabled": true,
+                  "force_delete_lun_in_storagegroup": true,
+                  "goodness_function": "",
+                  "gpfs_hosts": "",
+                  "gpfs_hosts_key_file": "$state_path/ssh_known_hosts",
+                  "gpfs_images_dir": "",
+                  "gpfs_images_share_mode": "",
+                  "gpfs_max_clone_depth": 0,
+                  "gpfs_mount_point_base": "",
+                  "gpfs_private_key": "",
+                  "gpfs_sparse_volumes": true,
+                  "gpfs_ssh_port": 22,
+                  "gpfs_storage_pool": "system",
+                  "gpfs_strict_host_key_policy": false,
+                  "gpfs_user_login": "root",
+                  "gpfs_user_password": "",
+                  "hpe3par_api_url": "",
+                  "hpe3par_cpg": "OpenStack",
+                  "hpe3par_cpg_snap": "",
+                  "hpe3par_debug": false,
+                  "hpe3par_iscsi_chap_enabled": false,
+                  "hpe3par_iscsi_ips": "",
+                  "hpe3par_password": "",
+                  "hpe3par_snapshot_expiration": "",
+                  "hpe3par_snapshot_retention": "",
+                  "hpe3par_target_nsp": "",
+                  "hpe3par_username": "",
+                  "hpelefthand_api_url": "",
+                  "hpelefthand_clustername": "",
+                  "hpelefthand_debug": false,
+                  "hpelefthand_iscsi_chap_enabled": false,
+                  "hpelefthand_password": "",
+                  "hpelefthand_ssh_port": 16022,
+                  "hpelefthand_username": "",
+                  "hpmsa_iscsi_ips": "",
+                  "hpmsa_pool_name": "A",
+                  "hpmsa_pool_type": "virtual",
+                  "hypermetro_devices": "",
+                  "iet_conf": "/etc/iet/ietd.conf",
+                  "ignore_pool_full_threshold": false,
+                  "infortrend_cli_cache": false,
+                  "infortrend_cli_max_retries": 5,
+                  "infortrend_cli_path": "/opt/bin/Infortrend/raidcmd_ESDS10.jar",
+                  "infortrend_cli_timeout": 60,
+                  "infortrend_iqn_prefix": "iqn.2002-10.com.infortrend",
+                  "infortrend_pools_name": "",
+                  "infortrend_slots_a_channels_id": "",
+                  "infortrend_slots_b_channels_id": "",
+                  "initiator_auto_deregistration": false,
+                  "initiator_auto_registration": false,
+                  "initiator_check": false,
+                  "instorage_mcs_allow_tenant_qos": false,
+                  "instorage_mcs_localcopy_rate": 50,
+                  "instorage_mcs_localcopy_timeout": 120,
+                  "instorage_mcs_vol_autoexpand": true,
+                  "instorage_mcs_vol_compression": false,
+                  "instorage_mcs_vol_grainsize": 256,
+                  "instorage_mcs_vol_intier": true,
+                  "instorage_mcs_vol_iogrp": "0",
+                  "instorage_mcs_vol_rsize": 2,
+                  "instorage_mcs_vol_warning": 0,
+                  "instorage_mcs_volpool_name": "volpool",
+                  "instorage_san_secondary_ip": "",
+                  "interval": 3,
+                  "io_port_list": "",
+                  "iscsi_initiators": "",
+                  "iscsi_iotype": "fileio",
+                  "iscsi_secondary_ip_addresses": "",
+                  "iscsi_target_flags": "",
+                  "iscsi_write_cache": "on",
+                  "java_path": "/usr/bin/java",
+                  "lenovo_iscsi_ips": "",
+                  "lenovo_pool_name": "A",
+                  "lenovo_pool_type": "virtual",
+                  "linstor_autoplace_count": 0,
+                  "linstor_controller_diskless": true,
+                  "linstor_default_blocksize": 4096,
+                  "linstor_default_storage_pool_name": "DfltStorPool",
+                  "linstor_default_uri": "linstor://localhost",
+                  "linstor_default_volume_group_name": "drbd-vg",
+                  "linstor_volume_downsize_factor": "4096",
+                  "lvm_conf_file": "/etc/cinder/lvm.conf",
+                  "lvm_mirrors": 0,
+                  "lvm_suppress_fd_warnings": false,
+                  "lvm_type": "auto",
+                  "management_ips": "",
+                  "max_luns_per_storage_group": 255,
+                  "metro_domain_name": "",
+                  "metro_san_address": "",
+                  "metro_san_password": "",
+                  "metro_san_user": "",
+                  "metro_storage_pools": "",
+                  "naviseccli_path": "",
+                  "nec_actual_free_capacity": false,
+                  "nec_auto_accesscontrol": true,
+                  "nec_backend_max_ld_count": 1024,
+                  "nec_backup_ldname_format": "LX:%s",
+                  "nec_backup_pools": "",
+                  "nec_cv_ldname_format": "LX:__ControlVolume_%xh",
+                  "nec_diskarray_name": "",
+                  "nec_ismcli_fip": "",
+                  "nec_ismcli_password": "",
+                  "nec_ismcli_privkey": "",
+                  "nec_ismcli_user": "",
+                  "nec_ismview_alloptimize": false,
+                  "nec_ismview_dir": "/tmp/nec/cinder",
+                  "nec_ldname_format": "LX:%s",
+                  "nec_ldset": "",
+                  "nec_pools": "",
+                  "nec_queryconfig_view": false,
+                  "nec_ssh_pool_port_number": 22,
+                  "nec_unpairthread_timeout": 3600,
+                  "netapp_vserver": "",
+                  "nexenta_blocksize": 4096,
+                  "nexenta_dataset_compression": "on",
+                  "nexenta_dataset_dedup": "off",
+                  "nexenta_dataset_description": "",
+                  "nexenta_folder": "",
+                  "nexenta_group_snapshot_template": "group-snapshot-%s",
+                  "nexenta_host": "",
+                  "nexenta_host_group_prefix": "cinder",
+                  "nexenta_iscsi_target_host_group": "all",
+                  "nexenta_iscsi_target_portal_groups": "",
+                  "nexenta_iscsi_target_portal_port": 3260,
+                  "nexenta_iscsi_target_portals": "",
+                  "nexenta_lu_writebackcache_disabled": false,
+                  "nexenta_luns_per_target": 100,
+                  "nexenta_ns5_blocksize": 32,
+                  "nexenta_origin_snapshot_template": "origin-snapshot-%s",
+                  "nexenta_rest_backoff_factor": "0.5",
+                  "nexenta_rest_connect_timeout": "30",
+                  "nexenta_rest_protocol": "auto",
+                  "nexenta_rest_read_timeout": "300",
+                  "nexenta_rest_retry_count": 3,
+                  "nexenta_sparse": false,
+                  "nexenta_target_group_prefix": "cinder",
+                  "nexenta_target_prefix": "iqn.1986-03.com.sun:02:cinder",
+                  "nexenta_use_https": true,
+                  "nexenta_volume": "cinder",
+                  "nexenta_volume_group": "iscsi",
+                  "num_shell_tries": 3,
+                  "num_volume_device_scan_tries": 3,
+                  "nvmet_port_id": 1,
+                  "podm_password": "",
+                  "podm_url": "",
+                  "podm_username": "",
+                  "powermax_array": "",
+                  "powermax_port_groups": "",
+                  "powermax_service_level": "",
+                  "powermax_snapvx_unlink_limit": 3,
+                  "powermax_srp": "",
+                  "proxy": "cinder.volume.drivers.ibm.ibm_storage.proxy.IBMStorageProxy",
+                  "pure_api_token": "",
+                  "pure_automatic_max_oversubscription_ratio": true,
+                  "pure_eradicate_on_delete": false,
+                  "pure_host_personality": "",
+                  "pure_iscsi_cidr": "0.0.0.0/0",
+                  "pure_replica_interval_default": 3600,
+                  "pure_replica_retention_long_term_default": 7,
+                  "pure_replica_retention_long_term_per_day_default": 3,
+                  "pure_replica_retention_short_term_default": 14400,
+                  "pure_replication_pg_name": "cinder-group",
+                  "pure_replication_pod_name": "cinder-pod",
+                  "qnap_management_url": "",
+                  "qnap_poolname": "",
+                  "qnap_storage_protocol": "iscsi",
+                  "quobyte_client_cfg": "",
+                  "quobyte_mount_point_base": "$state_path/mnt",
+                  "quobyte_overlay_volumes": false,
+                  "quobyte_qcow2_volumes": true,
+                  "quobyte_sparsed_volumes": true,
+                  "quobyte_volume_from_snapshot_cache": false,
+                  "quobyte_volume_url": "",
+                  "rados_connect_timeout": -1,
+                  "rados_connection_interval": 5,
+                  "rados_connection_retries": 3,
+                  "rbd_ceph_conf": "",
+                  "rbd_cluster_name": "ceph",
+                  "rbd_exclusive_cinder_pool": false,
+                  "rbd_flatten_volume_from_snapshot": false,
+                  "rbd_max_clone_depth": 5,
+                  "rbd_pool": "rbd",
+                  "rbd_secret_uuid": "",
+                  "rbd_store_chunk_size": 4,
+                  "rbd_user": "",
+                  "remove_empty_host": false,
+                  "report_discard_supported": false,
+                  "report_dynamic_total_capacity": true,
+                  "retries": 200,
+                  "san_ip": "",
+                  "san_login": "admin",
+                  "san_password": "",
+                  "san_private_key": "",
+                  "san_ssh_port": 22,
+                  "scst_target_driver": "iscsi",
+                  "scst_target_iqn_name": "",
+                  "secondary_san_ip": "",
+                  "secondary_san_login": "Admin",
+                  "secondary_san_password": "",
+                  "secondary_sc_api_port": 3033,
+                  "sf_account_prefix": "",
+                  "sf_allow_tenant_qos": false,
+                  "sf_api_port": 443,
+                  "sf_emulate_512": true,
+                  "sf_enable_vag": false,
+                  "sf_provisioning_calc": "maxProvisionedSpace",
+                  "sf_svip": "",
+                  "sf_volume_prefix": "UUID-",
+                  "sheepdog_store_address": "127.0.0.1",
+                  "sheepdog_store_port": 7000,
+                  "smbfs_default_volume_format": "vhd",
+                  "smbfs_mount_point_base": "C:\\OpenStack\\_mnt",
+                  "smbfs_pool_mappings": "",
+                  "smbfs_shares_config": "C:\\OpenStack\\smbfs_shares.txt",
+                  "spdk_max_queue_depth": "64",
+                  "spdk_rpc_ip": "",
+                  "spdk_rpc_password": "",
+                  "spdk_rpc_port": 8000,
+                  "spdk_rpc_username": "",
+                  "ssh_conn_timeout": 30,
+                  "storage_protocol": "iscsi",
+                  "storage_vnx_authentication_type": "global",
+                  "storage_vnx_pool_names": "",
+                  "storage_vnx_security_file_dir": "",
+                  "storpool_replication": 3,
+                  "storpool_template": "",
+                  "storwize_peer_pool": "",
+                  "storwize_preferred_host_site": "",
+                  "storwize_san_secondary_ip": "",
+                  "storwize_svc_allow_tenant_qos": false,
+                  "storwize_svc_flashcopy_rate": 50,
+                  "storwize_svc_flashcopy_timeout": 120,
+                  "storwize_svc_iscsi_chap_enabled": true,
+                  "storwize_svc_mirror_pool": "",
+                  "storwize_svc_multipath_enabled": false,
+                  "storwize_svc_stretched_cluster_partner": "",
+                  "storwize_svc_vol_autoexpand": true,
+                  "storwize_svc_vol_compression": false,
+                  "storwize_svc_vol_easytier": true,
+                  "storwize_svc_vol_grainsize": 256,
+                  "storwize_svc_vol_iogrp": "0",
+                  "storwize_svc_vol_nofmtdisk": false,
+                  "storwize_svc_vol_rsize": 2,
+                  "storwize_svc_vol_warning": 0,
+                  "storwize_svc_volpool_name": "volpool",
+                  "synology_admin_port": 5000,
+                  "synology_device_id": "",
+                  "synology_one_time_pass": "",
+                  "synology_password": "",
+                  "synology_pool_name": "",
+                  "synology_ssl_verify": true,
+                  "synology_username": "admin",
+                  "target_helper": "tgtadm",
+                  "target_ip_address": "$my_ip",
+                  "target_port": 3260,
+                  "target_prefix": "iqn.2010-10.org.openstack:",
+                  "target_protocol": "iscsi",
+                  "trace_flags": "",
+                  "u4p_failover_autofailback": true,
+                  "u4p_failover_backoff_factor": 1,
+                  "u4p_failover_retries": 3,
+                  "u4p_failover_target": "",
+                  "u4p_failover_timeout": 20,
+                  "unique_fqdn_network": true,
+                  "unity_io_ports": "",
+                  "unity_storage_pool_names": "",
+                  "use_chap_auth": false,
+                  "vmax_workload": "",
+                  "vmware_adapter_type": "lsiLogic",
+                  "vmware_api_retry_count": 10,
+                  "vmware_ca_file": "",
+                  "vmware_cluster_name": "",
+                  "vmware_connection_pool_size": 10,
+                  "vmware_datastore_regex": "",
+                  "vmware_host_ip": "",
+                  "vmware_host_password": "",
+                  "vmware_host_port": 443,
+                  "vmware_host_username": "",
+                  "vmware_host_version": "",
+                  "vmware_image_transfer_timeout_secs": 7200,
+                  "vmware_insecure": false,
+                  "vmware_lazy_create": true,
+                  "vmware_max_objects_retrieval": 100,
+                  "vmware_snapshot_format": "template",
+                  "vmware_task_poll_interval": "2.0",
+                  "vmware_tmp_dir": "/tmp",
+                  "vmware_volume_folder": "Volumes",
+                  "vmware_wsdl_location": "",
+                  "vnx_async_migrate": true,
+                  "volume_backend_name": "",
+                  "volume_clear": "zero",
+                  "volume_clear_ionice": "",
+                  "volume_clear_size": 0,
+                  "volume_copy_blkio_cgroup_name": "cinder-volume-copy",
+                  "volume_copy_bps_limit": 0,
+                  "volume_dd_blocksize": "1M",
+                  "volume_group": "cinder-volumes",
+                  "volumes_dir": "$state_path/volumes",
+                  "vrts_lun_sparse": true,
+                  "vrts_target_config": "/etc/cinder/vrts_target.xml",
+                  "vxflexos_allow_non_padded_volumes": false,
+                  "vxflexos_max_over_subscription_ratio": "10.0",
+                  "vxflexos_rest_server_port": 443,
+                  "vxflexos_round_volume_capacity": true,
+                  "vxflexos_server_api_version": "",
+                  "vxflexos_storage_pools": "",
+                  "vxflexos_unmap_volume_before_deletion": false,
+                  "vzstorage_default_volume_format": "raw",
+                  "vzstorage_mount_options": "",
+                  "vzstorage_mount_point_base": "$state_path/mnt",
+                  "vzstorage_shares_config": "/etc/cinder/vzstorage_shares",
+                  "vzstorage_sparsed_volumes": true,
+                  "vzstorage_used_ratio": "0.95",
+                  "windows_iscsi_lun_path": "C:\\iSCSIVirtualDisks",
+                  "xtremio_array_busy_retry_count": 5,
+                  "xtremio_array_busy_retry_interval": 5,
+                  "xtremio_clean_unused_ig": false,
+                  "xtremio_cluster_name": "",
+                  "zadara_access_key": "",
+                  "zadara_default_snap_policy": false,
+                  "zadara_ssl_cert_verify": true,
+                  "zadara_use_iser": true,
+                  "zadara_vol_encrypt": false,
+                  "zadara_vol_name_template": "OS_%s",
+                  "zadara_vpsa_host": "",
+                  "zadara_vpsa_poolname": "",
+                  "zadara_vpsa_port": "",
+                  "zadara_vpsa_use_ssl": false
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "ACCESSIscsi",
+                  "name": "",
+                  "vrts_lun_sparse": true,
+                  "vrts_target_config": "/etc/cinder/vrts_target.xml"
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "AS13000",
+                  "name": "",
+                  "as13000_ipsan_pools": "Pool0",
+                  "as13000_meta_pool": "",
+                  "as13000_token_available_time": 3300
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "FJDXFC",
+                  "name": "",
+                  "cinder_eternus_config_file": "/etc/cinder/cinder_fujitsu_eternus_dx.xml"
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "FJDXISCSI",
+                  "name": "",
+                  "cinder_eternus_config_file": "/etc/cinder/cinder_fujitsu_eternus_dx.xml"
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "FlashSystemFC",
+                  "name": "",
+                  "flashsystem_connection_protocol": "FC",
+                  "flashsystem_multihostmap_enabled": true
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "FlashSystemISCSI",
+                  "name": "",
+                  "flashsystem_connection_protocol": "FC",
+                  "flashsystem_multihostmap_enabled": true
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "GPFS",
+                  "name": "",
+                  "gpfs_images_dir": "",
+                  "gpfs_images_share_mode": "",
+                  "gpfs_max_clone_depth": 0,
+                  "gpfs_mount_point_base": "",
+                  "gpfs_sparse_volumes": true,
+                  "gpfs_storage_pool": "system"
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "GPFSRemote",
+                  "name": "",
+                  "gpfs_hosts": "",
+                  "gpfs_hosts_key_file": "$state_path/ssh_known_hosts",
+                  "gpfs_images_dir": "",
+                  "gpfs_images_share_mode": "",
+                  "gpfs_max_clone_depth": 0,
+                  "gpfs_mount_point_base": "",
+                  "gpfs_private_key": "",
+                  "gpfs_sparse_volumes": true,
+                  "gpfs_ssh_port": 22,
+                  "gpfs_storage_pool": "system",
+                  "gpfs_strict_host_key_policy": false,
+                  "gpfs_user_login": "root",
+                  "gpfs_user_password": ""
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "HPE3PARFC",
+                  "name": "",
+                  "hpe3par_api_url": "",
+                  "hpe3par_cpg": "OpenStack",
+                  "hpe3par_cpg_snap": "",
+                  "hpe3par_debug": false,
+                  "hpe3par_iscsi_chap_enabled": false,
+                  "hpe3par_iscsi_ips": "",
+                  "hpe3par_password": "",
+                  "hpe3par_snapshot_expiration": "",
+                  "hpe3par_snapshot_retention": "",
+                  "hpe3par_target_nsp": "",
+                  "hpe3par_username": "",
+                  "san_ip": "",
+                  "san_login": "admin",
+                  "san_password": "",
+                  "san_private_key": "",
+                  "san_ssh_port": 22,
+                  "ssh_conn_timeout": 30,
+                  "target_ip_address": "$my_ip",
+                  "target_port": 3260
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "HPE3PARISCSI",
+                  "name": "",
+                  "hpe3par_api_url": "",
+                  "hpe3par_cpg": "OpenStack",
+                  "hpe3par_cpg_snap": "",
+                  "hpe3par_debug": false,
+                  "hpe3par_iscsi_chap_enabled": false,
+                  "hpe3par_iscsi_ips": "",
+                  "hpe3par_password": "",
+                  "hpe3par_snapshot_expiration": "",
+                  "hpe3par_snapshot_retention": "",
+                  "hpe3par_target_nsp": "",
+                  "hpe3par_username": "",
+                  "san_ip": "",
+                  "san_login": "admin",
+                  "san_password": "",
+                  "san_private_key": "",
+                  "san_ssh_port": 22,
+                  "ssh_conn_timeout": 30,
+                  "target_ip_address": "$my_ip",
+                  "target_port": 3260
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "HPELeftHandISCSI",
+                  "name": "",
+                  "hpelefthand_api_url": "",
+                  "hpelefthand_clustername": "",
+                  "hpelefthand_debug": false,
+                  "hpelefthand_iscsi_chap_enabled": false,
+                  "hpelefthand_password": "",
+                  "hpelefthand_ssh_port": 16022,
+                  "hpelefthand_username": ""
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "HPMSAFC",
+                  "name": "",
+                  "hpmsa_pool_name": "A",
+                  "hpmsa_pool_type": "virtual"
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "HPMSAISCSI",
+                  "name": "",
+                  "hpmsa_iscsi_ips": "",
+                  "hpmsa_pool_name": "A",
+                  "hpmsa_pool_type": "virtual"
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "HedvigISCSI",
+                  "name": ""
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "HuaweiFC",
+                  "name": "",
+                  "cinder_huawei_conf_file": "/etc/cinder/cinder_huawei_conf.xml",
+                  "hypermetro_devices": "",
+                  "metro_domain_name": "",
+                  "metro_san_address": "",
+                  "metro_san_password": "",
+                  "metro_san_user": "",
+                  "metro_storage_pools": ""
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "HuaweiISCSI",
+                  "name": "",
+                  "cinder_huawei_conf_file": "/etc/cinder/cinder_huawei_conf.xml",
+                  "hypermetro_devices": "",
+                  "metro_domain_name": "",
+                  "metro_san_address": "",
+                  "metro_san_password": "",
+                  "metro_san_user": "",
+                  "metro_storage_pools": ""
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "IBMStorage",
+                  "name": "",
+                  "chap": "disabled",
+                  "connection_type": "iscsi",
+                  "management_ips": "",
+                  "proxy": "cinder.volume.drivers.ibm.ibm_storage.proxy.IBMStorageProxy"
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "InStorageMCSFC",
+                  "name": "",
+                  "instorage_mcs_allow_tenant_qos": false,
+                  "instorage_mcs_localcopy_rate": 50,
+                  "instorage_mcs_localcopy_timeout": 120,
+                  "instorage_mcs_vol_autoexpand": true,
+                  "instorage_mcs_vol_compression": false,
+                  "instorage_mcs_vol_grainsize": 256,
+                  "instorage_mcs_vol_intier": true,
+                  "instorage_mcs_vol_iogrp": "0",
+                  "instorage_mcs_vol_rsize": 2,
+                  "instorage_mcs_vol_warning": 0,
+                  "instorage_mcs_volpool_name": "volpool",
+                  "instorage_san_secondary_ip": ""
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "InStorageMCSISCSI",
+                  "name": "",
+                  "instorage_mcs_allow_tenant_qos": false,
+                  "instorage_mcs_localcopy_rate": 50,
+                  "instorage_mcs_localcopy_timeout": 120,
+                  "instorage_mcs_vol_autoexpand": true,
+                  "instorage_mcs_vol_compression": false,
+                  "instorage_mcs_vol_grainsize": 256,
+                  "instorage_mcs_vol_intier": true,
+                  "instorage_mcs_vol_iogrp": "0",
+                  "instorage_mcs_vol_rsize": 2,
+                  "instorage_mcs_vol_warning": 0,
+                  "instorage_mcs_volpool_name": "volpool",
+                  "instorage_san_secondary_ip": ""
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "InfortrendCLIFC",
+                  "name": "",
+                  "infortrend_cli_cache": false,
+                  "infortrend_cli_max_retries": 5,
+                  "infortrend_cli_path": "/opt/bin/Infortrend/raidcmd_ESDS10.jar",
+                  "infortrend_cli_timeout": 60,
+                  "infortrend_iqn_prefix": "iqn.2002-10.com.infortrend",
+                  "infortrend_pools_name": "",
+                  "infortrend_slots_a_channels_id": "",
+                  "infortrend_slots_b_channels_id": "",
+                  "java_path": "/usr/bin/java"
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "InfortrendCLIISCSI",
+                  "name": "",
+                  "infortrend_cli_cache": false,
+                  "infortrend_cli_max_retries": 5,
+                  "infortrend_cli_path": "/opt/bin/Infortrend/raidcmd_ESDS10.jar",
+                  "infortrend_cli_timeout": 60,
+                  "infortrend_iqn_prefix": "iqn.2002-10.com.infortrend",
+                  "infortrend_pools_name": "",
+                  "infortrend_slots_a_channels_id": "",
+                  "infortrend_slots_b_channels_id": "",
+                  "java_path": "/usr/bin/java"
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "KaminarioISCSI",
+                  "name": "",
+                  "disable_discovery": false,
+                  "san_ip": "",
+                  "san_login": "admin",
+                  "san_password": "",
+                  "unique_fqdn_network": true,
+                  "volume_dd_blocksize": "1M"
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "LVMVolume",
+                  "name": "",
+                  "iet_conf": "/etc/iet/ietd.conf",
+                  "iscsi_iotype": "fileio",
+                  "iscsi_secondary_ip_addresses": "",
+                  "iscsi_target_flags": "",
+                  "iscsi_write_cache": "on",
+                  "lvm_conf_file": "/etc/cinder/lvm.conf",
+                  "lvm_mirrors": 0,
+                  "lvm_suppress_fd_warnings": false,
+                  "lvm_type": "auto",
+                  "nvmet_port_id": 1,
+                  "scst_target_driver": "iscsi",
+                  "scst_target_iqn_name": "",
+                  "spdk_max_queue_depth": "64",
+                  "spdk_rpc_ip": "",
+                  "spdk_rpc_password": "",
+                  "spdk_rpc_port": 8000,
+                  "spdk_rpc_username": "",
+                  "target_helper": "tgtadm",
+                  "target_ip_address": "$my_ip",
+                  "target_port": 3260,
+                  "target_prefix": "iqn.2010-10.org.openstack:",
+                  "target_protocol": "iscsi",
+                  "volume_clear": "zero",
+                  "volume_clear_size": 0,
+                  "volume_dd_blocksize": "1M",
+                  "volume_group": "cinder-volumes",
+                  "volumes_dir": "$state_path/volumes"
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "LenovoFC",
+                  "name": "",
+                  "lenovo_pool_name": "A",
+                  "lenovo_pool_type": "virtual"
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "LenovoISCSI",
+                  "name": "",
+                  "lenovo_iscsi_ips": "",
+                  "lenovo_pool_name": "A",
+                  "lenovo_pool_type": "virtual"
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "LinstorDrbd",
+                  "name": "",
+                  "linstor_autoplace_count": 0,
+                  "linstor_controller_diskless": true,
+                  "linstor_default_blocksize": 4096,
+                  "linstor_default_storage_pool_name": "DfltStorPool",
+                  "linstor_default_uri": "linstor://localhost",
+                  "linstor_default_volume_group_name": "drbd-vg",
+                  "linstor_volume_downsize_factor": "4096"
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "LinstorIscsi",
+                  "name": "",
+                  "linstor_autoplace_count": 0,
+                  "linstor_controller_diskless": true,
+                  "linstor_default_blocksize": 4096,
+                  "linstor_default_storage_pool_name": "DfltStorPool",
+                  "linstor_default_uri": "linstor://localhost",
+                  "linstor_default_volume_group_name": "drbd-vg",
+                  "linstor_volume_downsize_factor": "4096"
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "MStorageFC",
+                  "name": "",
+                  "nec_actual_free_capacity": false,
+                  "nec_auto_accesscontrol": true,
+                  "nec_backend_max_ld_count": 1024,
+                  "nec_backup_ldname_format": "LX:%s",
+                  "nec_backup_pools": "",
+                  "nec_cv_ldname_format": "LX:__ControlVolume_%xh",
+                  "nec_diskarray_name": "",
+                  "nec_ismcli_fip": "",
+                  "nec_ismcli_password": "",
+                  "nec_ismcli_privkey": "",
+                  "nec_ismcli_user": "",
+                  "nec_ismview_alloptimize": false,
+                  "nec_ismview_dir": "/tmp/nec/cinder",
+                  "nec_ldname_format": "LX:%s",
+                  "nec_ldset": "",
+                  "nec_pools": "",
+                  "nec_queryconfig_view": false,
+                  "nec_ssh_pool_port_number": 22,
+                  "nec_unpairthread_timeout": 3600
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "MStorageISCSI",
+                  "name": "",
+                  "nec_actual_free_capacity": false,
+                  "nec_auto_accesscontrol": true,
+                  "nec_backend_max_ld_count": 1024,
+                  "nec_backup_ldname_format": "LX:%s",
+                  "nec_backup_pools": "",
+                  "nec_cv_ldname_format": "LX:__ControlVolume_%xh",
+                  "nec_diskarray_name": "",
+                  "nec_ismcli_fip": "",
+                  "nec_ismcli_password": "",
+                  "nec_ismcli_privkey": "",
+                  "nec_ismcli_user": "",
+                  "nec_ismview_alloptimize": false,
+                  "nec_ismview_dir": "/tmp/nec/cinder",
+                  "nec_ldname_format": "LX:%s",
+                  "nec_ldset": "",
+                  "nec_pools": "",
+                  "nec_queryconfig_view": false,
+                  "nec_ssh_pool_port_number": 22,
+                  "nec_unpairthread_timeout": 3600
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "MacroSANFC",
+                  "name": "",
+                  "backend_availability_zone": "",
+                  "chap_password": "",
+                  "chap_username": "",
+                  "chiscsi_conf": "/etc/chelsio-iscsi/chiscsi.conf",
+                  "driver_client_cert": "",
+                  "driver_client_cert_key": "",
+                  "driver_data_namespace": "",
+                  "driver_ssl_cert_path": "",
+                  "driver_ssl_cert_verify": false,
+                  "driver_use_ssl": false,
+                  "filter_function": "",
+                  "goodness_function": "",
+                  "iet_conf": "/etc/iet/ietd.conf",
+                  "iscsi_iotype": "fileio",
+                  "iscsi_secondary_ip_addresses": "",
+                  "iscsi_target_flags": "",
+                  "iscsi_write_cache": "on",
+                  "num_shell_tries": 3,
+                  "num_volume_device_scan_tries": 3,
+                  "report_discard_supported": false,
+                  "storage_protocol": "iscsi",
+                  "target_helper": "tgtadm",
+                  "target_ip_address": "$my_ip",
+                  "target_port": 3260,
+                  "target_prefix": "iqn.2010-10.org.openstack:",
+                  "target_protocol": "iscsi",
+                  "trace_flags": "",
+                  "use_chap_auth": false,
+                  "volume_backend_name": "",
+                  "volume_clear": "zero",
+                  "volume_clear_ionice": "",
+                  "volume_clear_size": 0,
+                  "volume_copy_blkio_cgroup_name": "cinder-volume-copy",
+                  "volume_copy_bps_limit": 0,
+                  "volume_dd_blocksize": "1M",
+                  "volumes_dir": "$state_path/volumes"
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "MacroSANISCSI",
+                  "name": "",
+                  "backend_availability_zone": "",
+                  "chap_password": "",
+                  "chap_username": "",
+                  "chiscsi_conf": "/etc/chelsio-iscsi/chiscsi.conf",
+                  "driver_client_cert": "",
+                  "driver_client_cert_key": "",
+                  "driver_data_namespace": "",
+                  "driver_ssl_cert_path": "",
+                  "driver_ssl_cert_verify": false,
+                  "driver_use_ssl": false,
+                  "filter_function": "",
+                  "goodness_function": "",
+                  "iet_conf": "/etc/iet/ietd.conf",
+                  "iscsi_iotype": "fileio",
+                  "iscsi_secondary_ip_addresses": "",
+                  "iscsi_target_flags": "",
+                  "iscsi_write_cache": "on",
+                  "num_shell_tries": 3,
+                  "num_volume_device_scan_tries": 3,
+                  "report_discard_supported": false,
+                  "storage_protocol": "iscsi",
+                  "target_helper": "tgtadm",
+                  "target_ip_address": "$my_ip",
+                  "target_port": 3260,
+                  "target_prefix": "iqn.2010-10.org.openstack:",
+                  "target_protocol": "iscsi",
+                  "trace_flags": "",
+                  "use_chap_auth": false,
+                  "volume_backend_name": "",
+                  "volume_clear": "zero",
+                  "volume_clear_ionice": "",
+                  "volume_clear_size": 0,
+                  "volume_copy_blkio_cgroup_name": "cinder-volume-copy",
+                  "volume_copy_bps_limit": 0,
+                  "volume_dd_blocksize": "1M",
+                  "volumes_dir": "$state_path/volumes"
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "NetAppCmodeFibreChannel",
+                  "name": "",
+                  "netapp_vserver": ""
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "NetAppCmodeISCSI",
+                  "name": "",
+                  "netapp_vserver": ""
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "NexentaISCSI",
+                  "name": "",
+                  "nexenta_blocksize": 4096,
+                  "nexenta_dataset_compression": "on",
+                  "nexenta_dataset_dedup": "off",
+                  "nexenta_dataset_description": "",
+                  "nexenta_folder": "",
+                  "nexenta_group_snapshot_template": "group-snapshot-%s",
+                  "nexenta_host": "",
+                  "nexenta_host_group_prefix": "cinder",
+                  "nexenta_iscsi_target_host_group": "all",
+                  "nexenta_iscsi_target_portal_groups": "",
+                  "nexenta_iscsi_target_portal_port": 3260,
+                  "nexenta_iscsi_target_portals": "",
+                  "nexenta_lu_writebackcache_disabled": false,
+                  "nexenta_luns_per_target": 100,
+                  "nexenta_ns5_blocksize": 32,
+                  "nexenta_origin_snapshot_template": "origin-snapshot-%s",
+                  "nexenta_rest_backoff_factor": "0.5",
+                  "nexenta_rest_connect_timeout": "30",
+                  "nexenta_rest_protocol": "auto",
+                  "nexenta_rest_read_timeout": "300",
+                  "nexenta_rest_retry_count": 3,
+                  "nexenta_sparse": false,
+                  "nexenta_target_group_prefix": "cinder",
+                  "nexenta_target_prefix": "iqn.1986-03.com.sun:02:cinder",
+                  "nexenta_use_https": true,
+                  "nexenta_volume": "cinder",
+                  "nexenta_volume_group": "iscsi"
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "PSSeriesISCSI",
+                  "name": "",
+                  "eqlx_cli_max_retries": 5,
+                  "eqlx_group_name": "group-0",
+                  "eqlx_pool": "default"
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "PowerMaxFC",
+                  "name": "",
+                  "driver_ssl_cert_verify": false,
+                  "initiator_check": false,
+                  "interval": 3,
+                  "powermax_array": "",
+                  "powermax_port_groups": "",
+                  "powermax_service_level": "",
+                  "powermax_snapvx_unlink_limit": 3,
+                  "powermax_srp": "",
+                  "retries": 200,
+                  "san_ip": "",
+                  "san_login": "admin",
+                  "san_password": "",
+                  "u4p_failover_autofailback": true,
+                  "u4p_failover_backoff_factor": 1,
+                  "u4p_failover_retries": 3,
+                  "u4p_failover_target": "",
+                  "u4p_failover_timeout": 20,
+                  "vmax_workload": ""
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "PowerMaxISCSI",
+                  "name": "",
+                  "chap_password": "",
+                  "chap_username": "",
+                  "driver_ssl_cert_verify": false,
+                  "initiator_check": false,
+                  "interval": 3,
+                  "powermax_array": "",
+                  "powermax_port_groups": "",
+                  "powermax_service_level": "",
+                  "powermax_snapvx_unlink_limit": 3,
+                  "powermax_srp": "",
+                  "retries": 200,
+                  "san_ip": "",
+                  "san_login": "admin",
+                  "san_password": "",
+                  "u4p_failover_autofailback": true,
+                  "u4p_failover_backoff_factor": 1,
+                  "u4p_failover_retries": 3,
+                  "u4p_failover_target": "",
+                  "u4p_failover_timeout": 20,
+                  "use_chap_auth": false,
+                  "vmax_workload": ""
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "PureFC",
+                  "name": "",
+                  "driver_ssl_cert_path": "",
+                  "driver_ssl_cert_verify": false,
+                  "pure_api_token": "",
+                  "pure_automatic_max_oversubscription_ratio": true,
+                  "pure_eradicate_on_delete": false,
+                  "pure_host_personality": "",
+                  "pure_iscsi_cidr": "0.0.0.0/0",
+                  "pure_replica_interval_default": 3600,
+                  "pure_replica_retention_long_term_default": 7,
+                  "pure_replica_retention_long_term_per_day_default": 3,
+                  "pure_replica_retention_short_term_default": 14400,
+                  "pure_replication_pg_name": "cinder-group",
+                  "pure_replication_pod_name": "cinder-pod",
+                  "san_ip": "",
+                  "use_chap_auth": false
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "PureISCSI",
+                  "name": "",
+                  "driver_ssl_cert_path": "",
+                  "driver_ssl_cert_verify": false,
+                  "pure_api_token": "",
+                  "pure_automatic_max_oversubscription_ratio": true,
+                  "pure_eradicate_on_delete": false,
+                  "pure_host_personality": "",
+                  "pure_iscsi_cidr": "0.0.0.0/0",
+                  "pure_replica_interval_default": 3600,
+                  "pure_replica_retention_long_term_default": 7,
+                  "pure_replica_retention_long_term_per_day_default": 3,
+                  "pure_replica_retention_short_term_default": 14400,
+                  "pure_replication_pg_name": "cinder-group",
+                  "pure_replication_pod_name": "cinder-pod",
+                  "san_ip": "",
+                  "use_chap_auth": false
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "QnapISCSI",
+                  "name": "",
+                  "chap_password": "",
+                  "chap_username": "",
+                  "driver_ssl_cert_verify": false,
+                  "qnap_management_url": "",
+                  "qnap_poolname": "",
+                  "qnap_storage_protocol": "iscsi",
+                  "san_login": "admin",
+                  "san_password": "",
+                  "target_ip_address": "$my_ip",
+                  "use_chap_auth": false
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "Quobyte",
+                  "name": "",
+                  "quobyte_client_cfg": "",
+                  "quobyte_mount_point_base": "$state_path/mnt",
+                  "quobyte_overlay_volumes": false,
+                  "quobyte_qcow2_volumes": true,
+                  "quobyte_sparsed_volumes": true,
+                  "quobyte_volume_from_snapshot_cache": false,
+                  "quobyte_volume_url": ""
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "RBD",
+                  "name": "",
+                  "deferred_deletion_delay": 0,
+                  "deferred_deletion_purge_interval": 60,
+                  "enable_deferred_deletion": false,
+                  "rados_connect_timeout": -1,
+                  "rados_connection_interval": 5,
+                  "rados_connection_retries": 3,
+                  "rbd_ceph_conf": "",
+                  "rbd_cluster_name": "ceph",
+                  "rbd_exclusive_cinder_pool": false,
+                  "rbd_flatten_volume_from_snapshot": false,
+                  "rbd_max_clone_depth": 5,
+                  "rbd_pool": "rbd",
+                  "rbd_secret_uuid": "",
+                  "rbd_store_chunk_size": 4,
+                  "rbd_user": "",
+                  "report_dynamic_total_capacity": true
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "RSD",
+                  "name": "",
+                  "podm_password": "",
+                  "podm_url": "",
+                  "podm_username": ""
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "SCFC",
+                  "name": "",
+                  "dell_api_async_rest_timeout": 15,
+                  "dell_api_sync_rest_timeout": 30,
+                  "dell_sc_api_port": 3033,
+                  "dell_sc_server_folder": "openstack",
+                  "dell_sc_ssn": 64702,
+                  "dell_sc_verify_cert": false,
+                  "dell_sc_volume_folder": "openstack",
+                  "dell_server_os": "Red Hat Linux 6.x",
+                  "excluded_domain_ips": "",
+                  "secondary_san_ip": "",
+                  "secondary_san_login": "Admin",
+                  "secondary_san_password": "",
+                  "secondary_sc_api_port": 3033
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "SCISCSI",
+                  "name": "",
+                  "dell_api_async_rest_timeout": 15,
+                  "dell_api_sync_rest_timeout": 30,
+                  "dell_sc_api_port": 3033,
+                  "dell_sc_server_folder": "openstack",
+                  "dell_sc_ssn": 64702,
+                  "dell_sc_verify_cert": false,
+                  "dell_sc_volume_folder": "openstack",
+                  "dell_server_os": "Red Hat Linux 6.x",
+                  "excluded_domain_ips": "",
+                  "secondary_san_ip": "",
+                  "secondary_san_login": "Admin",
+                  "secondary_san_password": "",
+                  "secondary_sc_api_port": 3033
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "SPDK",
+                  "name": ""
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "Sheepdog",
+                  "name": "",
+                  "sheepdog_store_address": "127.0.0.1",
+                  "sheepdog_store_port": 7000
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "SolidFire",
+                  "name": "",
+                  "driver_ssl_cert_verify": false,
+                  "san_ip": "",
+                  "san_login": "admin",
+                  "san_password": "",
+                  "sf_account_prefix": "",
+                  "sf_allow_tenant_qos": false,
+                  "sf_api_port": 443,
+                  "sf_emulate_512": true,
+                  "sf_enable_vag": false,
+                  "sf_provisioning_calc": "maxProvisionedSpace",
+                  "sf_svip": "",
+                  "sf_volume_prefix": "UUID-"
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "StorPool",
+                  "name": "",
+                  "storpool_replication": 3,
+                  "storpool_template": ""
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "StorwizeSVCFC",
+                  "name": "",
+                  "cycle_period_seconds": 300,
+                  "storwize_peer_pool": "",
+                  "storwize_preferred_host_site": "",
+                  "storwize_san_secondary_ip": "",
+                  "storwize_svc_allow_tenant_qos": false,
+                  "storwize_svc_flashcopy_rate": 50,
+                  "storwize_svc_flashcopy_timeout": 120,
+                  "storwize_svc_mirror_pool": "",
+                  "storwize_svc_multipath_enabled": false,
+                  "storwize_svc_stretched_cluster_partner": "",
+                  "storwize_svc_vol_autoexpand": true,
+                  "storwize_svc_vol_compression": false,
+                  "storwize_svc_vol_easytier": true,
+                  "storwize_svc_vol_grainsize": 256,
+                  "storwize_svc_vol_iogrp": "0",
+                  "storwize_svc_vol_nofmtdisk": false,
+                  "storwize_svc_vol_rsize": 2,
+                  "storwize_svc_vol_warning": 0,
+                  "storwize_svc_volpool_name": "volpool"
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "StorwizeSVCISCSI",
+                  "name": "",
+                  "cycle_period_seconds": 300,
+                  "storwize_peer_pool": "",
+                  "storwize_preferred_host_site": "",
+                  "storwize_san_secondary_ip": "",
+                  "storwize_svc_allow_tenant_qos": false,
+                  "storwize_svc_flashcopy_rate": 50,
+                  "storwize_svc_flashcopy_timeout": 120,
+                  "storwize_svc_iscsi_chap_enabled": true,
+                  "storwize_svc_mirror_pool": "",
+                  "storwize_svc_stretched_cluster_partner": "",
+                  "storwize_svc_vol_autoexpand": true,
+                  "storwize_svc_vol_compression": false,
+                  "storwize_svc_vol_easytier": true,
+                  "storwize_svc_vol_grainsize": 256,
+                  "storwize_svc_vol_iogrp": "0",
+                  "storwize_svc_vol_nofmtdisk": false,
+                  "storwize_svc_vol_rsize": 2,
+                  "storwize_svc_vol_warning": 0,
+                  "storwize_svc_volpool_name": "volpool"
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "SynoISCSI",
+                  "name": "",
+                  "chap_password": "",
+                  "chap_username": "",
+                  "driver_use_ssl": false,
+                  "iscsi_secondary_ip_addresses": "",
+                  "synology_admin_port": 5000,
+                  "synology_device_id": "",
+                  "synology_one_time_pass": "",
+                  "synology_password": "",
+                  "synology_pool_name": "",
+                  "synology_ssl_verify": true,
+                  "synology_username": "admin",
+                  "target_ip_address": "$my_ip",
+                  "target_port": 3260,
+                  "target_prefix": "iqn.2010-10.org.openstack:",
+                  "target_protocol": "iscsi",
+                  "use_chap_auth": false
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "Unity",
+                  "name": "",
+                  "remove_empty_host": false,
+                  "unity_io_ports": "",
+                  "unity_storage_pool_names": ""
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "VMwareVStorageObject",
+                  "name": "",
+                  "vmware_adapter_type": "lsiLogic",
+                  "vmware_api_retry_count": 10,
+                  "vmware_ca_file": "",
+                  "vmware_cluster_name": "",
+                  "vmware_connection_pool_size": 10,
+                  "vmware_datastore_regex": "",
+                  "vmware_host_ip": "",
+                  "vmware_host_password": "",
+                  "vmware_host_port": 443,
+                  "vmware_host_username": "",
+                  "vmware_host_version": "",
+                  "vmware_image_transfer_timeout_secs": 7200,
+                  "vmware_insecure": false,
+                  "vmware_lazy_create": true,
+                  "vmware_max_objects_retrieval": 100,
+                  "vmware_snapshot_format": "template",
+                  "vmware_task_poll_interval": "2.0",
+                  "vmware_tmp_dir": "/tmp",
+                  "vmware_volume_folder": "Volumes",
+                  "vmware_wsdl_location": ""
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "VMwareVcVmdk",
+                  "name": "",
+                  "vmware_adapter_type": "lsiLogic",
+                  "vmware_api_retry_count": 10,
+                  "vmware_ca_file": "",
+                  "vmware_cluster_name": "",
+                  "vmware_connection_pool_size": 10,
+                  "vmware_datastore_regex": "",
+                  "vmware_host_ip": "",
+                  "vmware_host_password": "",
+                  "vmware_host_port": 443,
+                  "vmware_host_username": "",
+                  "vmware_host_version": "",
+                  "vmware_image_transfer_timeout_secs": 7200,
+                  "vmware_insecure": false,
+                  "vmware_lazy_create": true,
+                  "vmware_max_objects_retrieval": 100,
+                  "vmware_snapshot_format": "template",
+                  "vmware_task_poll_interval": "2.0",
+                  "vmware_tmp_dir": "/tmp",
+                  "vmware_volume_folder": "Volumes",
+                  "vmware_wsdl_location": ""
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "VNX",
+                  "name": "",
+                  "default_timeout": 31536000,
+                  "destroy_empty_storage_group": false,
+                  "force_delete_lun_in_storagegroup": true,
+                  "ignore_pool_full_threshold": false,
+                  "initiator_auto_deregistration": false,
+                  "initiator_auto_registration": false,
+                  "io_port_list": "",
+                  "iscsi_initiators": "",
+                  "max_luns_per_storage_group": 255,
+                  "naviseccli_path": "",
+                  "storage_vnx_authentication_type": "global",
+                  "storage_vnx_pool_names": "",
+                  "storage_vnx_security_file_dir": "",
+                  "vnx_async_migrate": true
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "VZStorage",
+                  "name": "",
+                  "vzstorage_default_volume_format": "raw",
+                  "vzstorage_mount_options": "",
+                  "vzstorage_mount_point_base": "$state_path/mnt",
+                  "vzstorage_shares_config": "/etc/cinder/vzstorage_shares",
+                  "vzstorage_sparsed_volumes": true,
+                  "vzstorage_used_ratio": "0.95"
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "VxFlexOS",
+                  "name": "",
+                  "vxflexos_allow_non_padded_volumes": false,
+                  "vxflexos_max_over_subscription_ratio": "10.0",
+                  "vxflexos_rest_server_port": 443,
+                  "vxflexos_round_volume_capacity": true,
+                  "vxflexos_server_api_version": "",
+                  "vxflexos_storage_pools": "",
+                  "vxflexos_unmap_volume_before_deletion": false
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "WindowsISCSI",
+                  "name": "",
+                  "windows_iscsi_lun_path": "C:\\iSCSIVirtualDisks"
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "WindowsSmbfs",
+                  "name": "",
+                  "smbfs_default_volume_format": "vhd",
+                  "smbfs_mount_point_base": "C:\\OpenStack\\_mnt",
+                  "smbfs_pool_mappings": "",
+                  "smbfs_shares_config": "C:\\OpenStack\\smbfs_shares.txt"
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "XtremIOFC",
+                  "name": "",
+                  "driver_ssl_cert_path": "",
+                  "driver_ssl_cert_verify": false,
+                  "san_ip": "",
+                  "san_login": "admin",
+                  "san_password": "",
+                  "xtremio_array_busy_retry_count": 5,
+                  "xtremio_array_busy_retry_interval": 5,
+                  "xtremio_clean_unused_ig": false,
+                  "xtremio_cluster_name": ""
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "XtremIOISCSI",
+                  "name": "",
+                  "driver_ssl_cert_path": "",
+                  "driver_ssl_cert_verify": false,
+                  "san_ip": "",
+                  "san_login": "admin",
+                  "san_password": "",
+                  "xtremio_array_busy_retry_count": 5,
+                  "xtremio_array_busy_retry_interval": 5,
+                  "xtremio_clean_unused_ig": false,
+                  "xtremio_cluster_name": ""
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ember-csi.io/v1alpha1",
+          "kind": "EmberCSI",
+          "metadata": {
+            "name": "example"
+          },
+          "spec": {
+            "config": {
+              "envVars": {
+                "X_CSI_PERSISTENCE_CONFIG": {
+                  "storage": "crd"
+                },
+                "X_CSI_DEBUG_MODE": "",
+                "X_CSI_DEFAULT_MOUNT_FS": "ext4",
+                "X_CSI_EMBER_CONFIG": {
+                  "grpc_workers": 30,
+                  "disable_logs": false,
+                  "plugin_name": "",
+                  "slow_operations": true,
+                  "disabled": "[]",
+                  "enable_probe": false,
+                  "debug": false,
+                  "user_id": "ember_csi.io",
+                  "project_id": "ember_csi.io"
+                },
+                "X_CSI_BACKEND_CONFIG": {
+                  "enable_unsupported_driver": false,
+                  "driver": "ZadaraVPSAISCSI",
+                  "name": "",
+                  "zadara_access_key": "",
+                  "zadara_default_snap_policy": false,
+                  "zadara_ssl_cert_verify": true,
+                  "zadara_use_iser": true,
+                  "zadara_vol_encrypt": false,
+                  "zadara_vol_name_template": "OS_%s",
+                  "zadara_vpsa_host": "",
+                  "zadara_vpsa_poolname": "",
+                  "zadara_vpsa_port": "",
+                  "zadara_vpsa_use_ssl": false
+                }
+              },
+              "sysFiles": {
+                "name": "",
+                "key": ""
+              }
+            }
+          }
+        }
+      ]
+    # END AUTO GENERATED EXAMPLES
+  name: ember-csi-operator.v0.0.1
+  namespace: ember-csi
+spec:
+  apiservicedefinitions: {}
+  maturity: alpha
+  version: 0.0.1
+  minKubeVersion: 1.11.0
+  description: |-
+     Operator to deploy Ember-CSI, a multi-vendor CSI plugin driver supporting over 80 storage drivers in a single plugin to provide block and mount storage to container orchestration systems.
+  displayName: Ember CSI Operator
+  keywords: ['Ember-CSI', 'CSI']
+  maintainers:
+  - name: Gorka Eguileor
+    email: geguileo@redhat.com
+  - name: Christian Schwede
+    email: cschwede@redhat.com
+  - name: Kiran Thyagaraja
+    email: kthyagar@redhat.com
+  provider:
+    name: Red Hat
+  labels:
+    operated-by: ember-csi.io
+  selector:
+    matchLabels:
+      operated-by: ember-csi.io
+  links:
+  - name: Learn more about the project
+    url: http://ember-csi.io/
+  - name: Documentation
+    url: http://readthedocs.org/projects/ember-csi/
+  - name: Ember-CSI Source Code
+    url: https://github.com/embercsi/ember-csi
+  - name: Ember-CSI Operator Source Code
+    url: https://github.com/embercsi/ember-csi-operator
+  icon:
+    - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjxzdmcKICAgeG1sbnM6ZGM9Imh0dHA6Ly9wdXJsLm9yZy9kYy9lbGVtZW50cy8xLjEvIgogICB4bWxuczpjYz0iaHR0cDovL2NyZWF0aXZlY29tbW9ucy5vcmcvbnMjIgogICB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiCiAgIHhtbG5zOnN2Zz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgdmlld0JveD0iMCAwIDEwNi41NDIzMiAxMzguNzkwODUiCiAgIGhlaWdodD0iMTM4Ljc5MDg1IgogICB3aWR0aD0iMTA2LjU0MjMyIgogICB4bWw6c3BhY2U9InByZXNlcnZlIgogICBpZD0ic3ZnNDc2NiIKICAgdmVyc2lvbj0iMS4xIj48bWV0YWRhdGEKICAgICBpZD0ibWV0YWRhdGE0NzcyIj48cmRmOlJERj48Y2M6V29yawogICAgICAgICByZGY6YWJvdXQ9IiI+PGRjOmZvcm1hdD5pbWFnZS9zdmcreG1sPC9kYzpmb3JtYXQ+PGRjOnR5cGUKICAgICAgICAgICByZGY6cmVzb3VyY2U9Imh0dHA6Ly9wdXJsLm9yZy9kYy9kY21pdHlwZS9TdGlsbEltYWdlIiAvPjxkYzp0aXRsZT48L2RjOnRpdGxlPjwvY2M6V29yaz48L3JkZjpSREY+PC9tZXRhZGF0YT48ZGVmcwogICAgIGlkPSJkZWZzNDc3MCI+PGNsaXBQYXRoCiAgICAgICBpZD0iY2xpcFBhdGg0NzgyIgogICAgICAgY2xpcFBhdGhVbml0cz0idXNlclNwYWNlT25Vc2UiPjxwYXRoCiAgICAgICAgIGlkPSJwYXRoNDc4MCIKICAgICAgICAgZD0iTSAwLDE1MCBIIDMwMCBWIDAgSCAwIFoiIC8+PC9jbGlwUGF0aD48L2RlZnM+PGcKICAgICB0cmFuc2Zvcm09Im1hdHJpeCgxLjMzMzMzMzMsMCwwLC0xLjMzMzMzMzMsLTEwMS45OTEyNSwxODIuNzI5MikiCiAgICAgaWQ9Imc0Nzc0Ij48ZwogICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTMzLjU1MzI1MikiCiAgICAgICBpZD0iZzQ5MzUiPjxnCiAgICAgICAgIGlkPSJnNDc4NCIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTQyLjAwMzksNzcuNjA3OSkiPjxwYXRoCiAgICAgICAgICAgZD0ibSAwLDAgYyAyLjY1NywtMC45ODMgMy4wOTgsLTIuNjA3IDMuOTE2LC00LjMxMiAwLjgxOCwtMS43MDUgMC44ODUsLTMuNjQxIDEuMTI0LC01LjUwOCAwLjIzOCwtMS44NjYgMC43MjYsLTMuODI3IDIuMTQ0LC01LjEyMSAxLjM3OSwtMS4yNTkgMy41NTUsLTEuNjUzIDUuMzQyLC0wLjk2OCAxLjc4NywwLjY4NyAzLjA5LDIuNDE1IDMuMTk4LDQuMjQ1IDAuMTE3LDEuOTgyIC0xLjI4NCw0LjgwMSAtMi42NSw2LjI4MiBDIDkuNzE5LC0xLjc0NCA1LjA4NSwtMC4zOTkgMCwwIgogICAgICAgICAgIHN0eWxlPSJmaWxsOiNlOWFhMjk7ZmlsbC1vcGFjaXR5OjE7ZmlsbC1ydWxlOm5vbnplcm87c3Ryb2tlOm5vbmUiCiAgICAgICAgICAgaWQ9InBhdGg0Nzg2IiAvPjwvZz48ZwogICAgICAgICBpZD0iZzQ3ODgiCiAgICAgICAgIHRyYW5zZm9ybT0idHJhbnNsYXRlKDE4NS4xNDY1LDkwLjU5NTIpIj48cGF0aAogICAgICAgICAgIGQ9Im0gMCwwIGMgMy41MzMsLTYuMDk5IDUuMTQyLC0xMy4zNzQgNC43NDksLTIwLjU5NyAtMC41MiwtNy4yMDEgLTIuODkyLC0xNC40MzEgLTcuMjczLC0yMC4zNzUgLTEuMDA2LC0xLjU1MSAtMi4yODgsLTIuODgzIC0zLjQ4MiwtNC4yOTYgLTAuNjQxLC0wLjY2MyAtMS4zMzUsLTEuMjc1IC0yLjAwNSwtMS45MTQgLTAuMzQsLTAuMzE0IC0wLjY3LC0wLjYzOSAtMS4wMTksLTAuOTQyIGwgLTEuMDk3LC0wLjg1IGMgLTIuODU5LC0yLjM2NSAtNi4xNTEsLTQuMTYyIC05LjU1MiwtNS42NTMgbCAtMi42MSwtMC45OTMgYyAtMC44NzUsLTAuMzE4IC0xLjc5MywtMC41IC0yLjY5LC0wLjc1NCAtMS43ODYsLTAuNTUxIC0zLjY1MSwtMC43MTkgLTUuNDg3LC0xLjAzOCAtMy43MDIsLTAuMyAtNy40NjMsLTAuMzk4IC0xMS4xNDQsMC4yODYgbCAtMS4zODIsMC4yMTcgYyAtMC40NiwwLjA4IC0wLjkwNiwwLjIyNSAtMS4zNTksMC4zMzQgbCAtMi43MDcsMC43MTQgLTIuNjI2LDAuOTY3IGMgLTAuNDM2LDAuMTY3IC0wLjg3OCwwLjMxNyAtMS4zMDYsMC40OTkgbCAtMS4yNTgsMC42MTEgYyAtMy40MDYsMS41MjkgLTYuNDk5LDMuNjggLTkuMzIsNi4wODggbCAtMi4wMzQsMS45MDggYyAtMC42NjIsMC42NTEgLTEuMjQzLDEuMzggLTEuODY2LDIuMDY3IGwgLTAuOTE4LDEuMDQ2IGMgLTAuMjg3LDAuMzYzIC0wLjU1LDAuNzQ3IC0wLjgyNSwxLjEyIC0wLjUzOSwwLjc1NCAtMS4wOTcsMS40OTUgLTEuNjE2LDIuMjYgLTEuOTY0LDMuMTQyIC0zLjU4MSw2LjQ5OCAtNC42MTksMTAuMDQyIC0wLjk3NywzLjU0MyAtMS43MDMsNy4xODMgLTEuNjQyLDEwLjg0OCAtMC4wOTYsMy42NTEgMC4zOTcsNy4yOTggMS4zNDYsMTAuNzg5IDEuOTQyLDYuOTc0IDUuODQxLDEzLjMyNCAxMS4xMzksMTcuOTY2IC00LjQ4OCwtNS40MDkgLTcuNTY0LC0xMS44MTYgLTguNzQ2LC0xOC41MTcgLTAuNjE2LC0zLjMzNiAtMC44MjMsLTYuNzQ1IC0wLjQ2NSwtMTAuMDkxIDAuMTk5LC0zLjM1OCAxLjAwNiwtNi42MzUgMi4wNzQsLTkuNzc4IDQuNCwtMTIuNjE4IDE1Ljk1OCwtMjIuMTcyIDI4Ljk0MSwtMjQuMTYgMy4yMjMsLTAuNjQ3IDYuNTQyLC0wLjU3OSA5LjgxMiwtMC4zNjMgMS42MTcsMC4yNzUgMy4yNjgsMC4zODUgNC44NDUsMC44NjUgMC43OTEsMC4yMTggMS42MDYsMC4zNiAyLjM4LDAuNjM1IGwgMi4zMjgsMC44MTQgYyAzLjA0MywxLjIyMiA2LjAzMiwyLjcwNyA4LjY1LDQuNzQgbCAxLjAwOSwwLjcyNCBjIDAuMzIxLDAuMjYgMC42MjQsMC41NDMgMC45MzcsMC44MTQgbCAxLjg2NywxLjY0MiBjIDEuMTI5LDEuMjExIDIuMzY3LDIuMzQxIDMuMzQzLDMuNjk0IDQuMjE1LDUuMTc0IDYuODkzLDExLjU2OCA3Ljk0NywxOC4yNzcgQyAzLjMzOCwtMTMuNjE5IDIuNTI3LC02LjU2MiAwLDAiCiAgICAgICAgICAgc3R5bGU9ImZpbGw6I2UxNzUxYztmaWxsLW9wYWNpdHk6MTtmaWxsLXJ1bGU6bm9uemVybztzdHJva2U6bm9uZSIKICAgICAgICAgICBpZD0icGF0aDQ3OTAiIC8+PC9nPjxnCiAgICAgICAgIGlkPSJnNDc5MiIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTQ4LjIzNzMsNDYuNTY5MykiPjxwYXRoCiAgICAgICAgICAgZD0ibSAwLDAgYyAxLjU3MSwtMC4xNjIgMy4xNTQsLTAuMjA5IDQuNzMyLC0wLjEzIDMuMzQ0LDAuMTY3IDYuNjUsMC45MSA5LjczMywyLjIxOSAyLjMzMSwwLjk4OCA2LjI1LDIuNjcyIDcuNjMyLDQuODY1IDIuMjcsMy42MDMgMi4wODQsOS4yMSAxLjQ4MywxMy4yNTQgLTEuNDc5LDkuOTYyIC05Ljk4NCwxOC40NyAtMTkuNTQ1LDIxLjc4OSA0LjI4OSwtMS40ODggOC4zOSwtNS43MzkgMTAuNzAyLC05LjY3OSAyLjUxMywtNC4yOCAyLjUzOCwtOC43MTQgMC44MzgsLTEzLjEyIC0yLjE1OCwtNS41OTIgLTcuMTU5LC04LjgxMyAtMTMuMDk5LC04LjgxMyAtNy4xNCwwIC0xMy44NzMsNS45MTIgLTE0LjIzLDEzLjIyNyAtMC40MDIsOC4yMzkgNi41NjgsMTYuNDIxIDExLjI2OSwyMi40NzggMTMuNzc5LDE3Ljc1OCAyLjgsNDQuMzg0IDIuNzk4LDQ0LjM4NyBDIDEuNDk1LDgwLjk1MyAtMC44MjYsNzIuMDMgLTcuMDYzLDY0LjcyIC0xMi41Nyw1OC4yNjUgLTE5LjU4OCw1Mi45NzQgLTIzLjgwOCw0NS40OTMgYyAtMS45NzgsLTMuNTA2IC0zLjM1NiwtNy4zNzEgLTMuODc3LC0xMS44NzcgLTAuODQyLC03LjI2OSAwLjg5OCwtMTQuODE0IDUuMTEzLC0yMC44MjcgQyAtMTcuNDI2LDUuNDQ4IC04Ljg0MSwwLjkwNyAwLDAiCiAgICAgICAgICAgc3R5bGU9ImZpbGw6I2IxNDkyZTtmaWxsLW9wYWNpdHk6MTtmaWxsLXJ1bGU6bm9uemVybztzdHJva2U6bm9uZSIKICAgICAgICAgICBpZD0icGF0aDQ3OTQiIC8+PC9nPjxnCiAgICAgICAgIGlkPSJnNDc5NiIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTQ5LjU5NDIsNDYuNDYxOSkiPjxwYXRoCiAgICAgICAgICAgZD0ibSAwLDAgYyAwLjM5LC0wLjAyMiAwLjc3OCwtMC4wNCAxLjE2NCwtMC4wNDkgLTkuNTg2LDQuMDM1IC0xNC4zMTEsMTEuNTQ3IC0xNS4zMDIsMjAuNDI5IC0wLjUwNiw0LjU0MSAwLjkxMyw4Ljg5MSAzLjI3OSwxMi42ODMgMi4zNjQsNC44NjIgNi4xMiw5LjQwMiA5LjAxNywxMy4xMzUgMTMuNzc5LDE3Ljc1NyAyLjgsNDQuMzg0IDIuNzk5LDQ0LjM4NiBDIDAuMTM4LDgxLjA2MSAtMi4xODMsNzIuMTM4IC04LjQyLDY0LjgyNyAtMTMuOTI3LDU4LjM3MyAtMjAuOTQ1LDUzLjA4MSAtMjUuMTY1LDQ1LjYgYyAtMS45NzgsLTMuNTA2IC0zLjM1NiwtNy4zNzEgLTMuODc3LC0xMS44NzYgLTAuODQyLC03LjI3IDAuODk4LC0xNC44MTUgNS4xMTMsLTIwLjgyOCBDIC0xOC43ODMsNS41NTYgLTEwLjE5OCwxLjAxNSAtMS4zNTcsMC4xMDcgLTAuOTQ5LDAuMDY1IC0wLjU0MywwLjAzMyAtMC4xNDEsMC4wMDggLTAuMDk0LDAuMDA1IC0wLjA0NywwLjAwMyAwLDAiCiAgICAgICAgICAgc3R5bGU9ImZpbGw6I2Q3NzIzMDtmaWxsLW9wYWNpdHk6MTtmaWxsLXJ1bGU6bm9uemVybztzdHJva2U6bm9uZSIKICAgICAgICAgICBpZD0icGF0aDQ3OTgiIC8+PC9nPjxnCiAgICAgICAgIGlkPSJnNDgwMCIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTc0LjM5MjYsNTcuNDY4OCkiPjxwYXRoCiAgICAgICAgICAgZD0ibSAwLDAgYyA0LjQ5OSw1LjM3OCA1LjQ1NCwxMy45MzggNS40NDEsMTkuOTg4IC0wLjAxMiw2IC0xLjU1NywxMi4wNjEgLTUuMDM3LDE3LjI3NyAtMi44NTEsNC4yNzYgLTYuOTAxLDcuODcgLTEwLjI0LDExLjg4MSAtMy4zNCw0LjAxMiAtNi4wNDIsOC43NDggLTUuNTcsMTMuNjUxIC0yLjc5MiwtMy4wMDYgLTMuMzk0LC03LjAwNiAtMi42MTMsLTEwLjkyNCAwLjY4MywtMy40MjIgMi41MzcsLTYuNTczIDMuNzY4LC05Ljg0NCAwLjkxNywtMi40MzkgMS45MTUsLTQuODY2IDIuNDQ3LC03LjQyNiAwLjU4NSwtMi44MTYgMC4yOTMsLTUuMDQ1IC0wLjc1NSwtNy42NzkgMS41ODYsLTEuMzczIDMuMTYzLC0yLjk3NiA0LjI5NiwtNC43NTMgMS4xMzUsLTEuNzc3IDEuMzk4LC0zLjk1NCAyLjM5MiwtNS44MDQgMi4yNjYsLTQuMjIgMy4wMzcsLTkuMTE4IDIuNTQ2LC0xMy44OTgiCiAgICAgICAgICAgc3R5bGU9ImZpbGw6I2UwYTgzMjtmaWxsLW9wYWNpdHk6MTtmaWxsLXJ1bGU6bm9uemVybztzdHJva2U6bm9uZSIKICAgICAgICAgICBpZD0icGF0aDQ4MDIiIC8+PC9nPjxnCiAgICAgICAgIGlkPSJnNDgwNCIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTYyLjc5OTgsMTAyLjU3MjMpIj48cGF0aAogICAgICAgICAgIGQ9Ik0gMCwwIEMgLTMuMjI5LDQuNjc4IC02LjkwOCwxMi4wMjggLTMuODEzLDE3LjY5NCAtNi42MDUsMTQuNjg4IC03LjIwNywxMC42ODcgLTYuNDI2LDYuNzcgYyAwLjY4MywtMy40MjMgMi41MzYsLTYuNTc0IDMuNzY4LC05Ljg0NSAwLjkxNywtMi40MzggMS45MTUsLTQuODY2IDIuNDQ3LC03LjQyNSAwLjU4NSwtMi44MTcgMC4yOTMsLTUuMDQ2IC0wLjc1NSwtNy42NzkgMS41ODYsLTEuMzc0IDMuMTYyLC0yLjk3NiA0LjI5NiwtNC43NTMgMS4xMzUsLTEuNzc4IDEuMzk4LC0zLjk1NCAyLjM5MiwtNS44MDQgMC4yMjEsLTAuNDEzIDAuNDI0LC0wLjgzNSAwLjYxOCwtMS4yNiBsIDEuMDcsLTAuMDYyIGMgMCwwIDIuMjc1LDcuOTYyIDEuMjcyLDE1LjE4MiBDIDcuODcsLTkuMDQzIDMuMjA2LC00LjY0NSAwLDAiCiAgICAgICAgICAgc3R5bGU9ImZpbGw6I2MzNTAyZTtmaWxsLW9wYWNpdHk6MTtmaWxsLXJ1bGU6bm9uemVybztzdHJva2U6bm9uZSIKICAgICAgICAgICBpZD0icGF0aDQ4MDYiIC8+PC9nPjxnCiAgICAgICAgIGlkPSJnNDgwOCIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTUwLjc1ODMsNDYuNDEzMSkiPjxwYXRoCiAgICAgICAgICAgZD0ibSAwLDAgYyAwLDAgMTQuMTcsMy42OTEgMTYuNjY5LDE4Ljc5MyAyLjE4NiwxMy4yMDUgLTkuMTM3LDIxLjE4MyAtMTUuMTU1LDIzLjM2IDAsMCAxMy4xNzgsMC44OTggMjAuMTIxLC02Ljg0OSBDIDI4LjU3OSwyNy41NTggMjguMTEsMTkuMDg2IDI0LjI4OCwxMi4wNzEgMjAuMjIxLDQuNjA4IDkuMDE5LC0wLjY4MiAwLDAiCiAgICAgICAgICAgc3R5bGU9ImZpbGw6I2Q3NzIzMDtmaWxsLW9wYWNpdHk6MTtmaWxsLXJ1bGU6bm9uemVybztzdHJva2U6bm9uZSIKICAgICAgICAgICBpZD0icGF0aDQ4MTAiIC8+PC9nPjxnCiAgICAgICAgIGlkPSJnNDgxMiIKICAgICAgICAgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTUwLjc1ODMsNDYuNDEzMSkiPjxwYXRoCiAgICAgICAgICAgZD0iTSAwLDAgQyAxNS42MTcsMS4zMyAyMy45ODksMTQuMDQxIDIxLjQ1MywyNi4yNDEgMTkuMDc1LDM3LjY3NyAxLjUxNCw0Mi4xNTMgMS41MTQsNDIuMTUzIDcuNTMyLDM5Ljk3NiAxOC44NTUsMzEuOTk4IDE2LjY2OSwxOC43OTMgMTQuMTcsMy42OTEgMCwwIDAsMCIKICAgICAgICAgICBzdHlsZT0iZmlsbDojZTBhODMyO2ZpbGwtb3BhY2l0eToxO2ZpbGwtcnVsZTpub256ZXJvO3N0cm9rZTpub25lIgogICAgICAgICAgIGlkPSJwYXRoNDgxNCIgLz48L2c+PGcKICAgICAgICAgaWQ9Imc0ODE2IgogICAgICAgICB0cmFuc2Zvcm09InRyYW5zbGF0ZSgxMjcuNTkxMyw3Ni45MjI5KSI+PHBhdGgKICAgICAgICAgICBkPSJtIDAsMCBjIDEuMDk0LDkuMjEzIDcuMTk4LDE1LjYzIDEyLjk5LDIyLjQwMiA0LjgyMiw1LjYzOCA5LjA1NiwxMS45NTUgMTAuNTkzLDE5LjMxMyAxLjIzOCw1LjkzNSAxLjMsMTIuNTkgLTAuNjI0LDE4LjQwOSBDIDIyLjE0MSw1MC42IDE5LjgyLDQxLjY3NyAxMy41ODMsMzQuMzY2IDguMDc2LDI3LjkxMiAxLjA1OCwyMi42MiAtMy4xNjIsMTUuMTM5IC01LjE0LDExLjYzMyAtNi41MTgsNy43NjggLTcuMDM5LDMuMjYzIGMgLTAuODQyLC03LjI3IDAuODk4LC0xNC44MTUgNS4xMTMsLTIwLjgyNyA1LjE0NiwtNy4zNDEgMTMuNzMxLC0xMS44ODIgMjIuNTcyLC0xMi43OSAwLjQwOCwtMC4wNDIgMC44MTMsLTAuMDc0IDEuMjE2LC0wLjA5OSAwLjA0NywtMC4wMDMgMC4wOTQsLTAuMDA1IDAuMTQxLC0wLjAwOCAwLjM5LC0wLjAyMiAwLjc3OCwtMC4wNCAxLjE2NCwtMC4wNDkgLTYuNDU0LDAuODgzIC0xMi4yNTQsMy4xMjggLTE2LjQ2MSw3LjQ3IEMgMC45NTQsLTE3LjEwMyAtMC45NTEsLTguMDEgMCwwIgogICAgICAgICAgIHN0eWxlPSJmaWxsOiNlMGE4MzI7ZmlsbC1vcGFjaXR5OjE7ZmlsbC1ydWxlOm5vbnplcm87c3Ryb2tlOm5vbmUiCiAgICAgICAgICAgaWQ9InBhdGg0ODE4IiAvPjwvZz48L2c+PC9nPjwvc3ZnPg==
+      mediatype: image/svg+xml
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: true
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+      - serviceAccountName: ember-csi-operator
+        rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - ember-csi.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+
+      clusterPermissions:
+      - serviceAccountName: ember-csi-operator
+        rules:
+        - apiGroups:
+          - "security.openshift.io"
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+          resourceNames:
+          - privileged
+          - hostmount-anyuid
+        - apiGroups:
+          - ember-csi.io
+          resources:
+          - "*"
+          verbs:
+          - "*"
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrole
+          - clusterrolebindings
+          - role
+          - rolebindings
+          - serviceaccounts
+          verbs:
+          - get
+          - create
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - list
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumes
+          verbs:
+          - create
+          - delete
+          - list
+          - get
+          - watch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - volumeattachments
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+          - delete
+          - create
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          - csinodes
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+          - delete
+        - apiGroups:
+          - "*"
+          resources:
+          - events
+          verbs:
+          - create
+          - list
+          - watch
+          - update
+          - delete
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - volumesnapshotclasses
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - volumesnapshotcontents
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+          - delete
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - volumesnapshots
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+        - apiGroups:
+          - csi.storage.k8s.io
+          resources:
+          - csidrivers
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+          - update
+          - delete
+      deployments:
+      - name: ember-csi-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: ember-csi-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: ember-csi-operator
+            spec:
+              containers:
+              - command:
+                - ember-csi-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: ember-csi-operator
+                image: docker.io/embercsi/ember-csi-operator:latest
+                imagePullPolicy: Always
+                name: ember-csi-operator
+                ports:
+                - containerPort: 60000
+                  name: metrics
+                readinessProbe:
+                  exec:
+                    command:
+                    - stat
+                    - /tmp/operator-sdk-ready
+                  failureThreshold: 1
+                  initialDelaySeconds: 4
+                  periodSeconds: 10
+                resources: {}
+              serviceAccountName: ember-csi-operator
+
+  customresourcedefinitions:
+    owned:
+    - kind: EmberCSI
+      name: embercsis.ember-csi.io
+      version: v1alpha1
+      displayName: Deployments
+      description: Represents a deployment of EmberCSI driver
+      resources:
+      - kind: StorageClass
+        name: ''
+        version: v1
+      - kind: StatefulSet
+        name: ''
+        version: v1
+      - kind: EmberCSI
+        name: ''
+        version: v1alpha
+      - kind: Daemonset
+        name: ''
+        version: v1
+      statusDescriptors:
+        - description: The installed Ember CSI version
+          displayName: Version
+          path: version
+      specDescriptors:
+        - description: Define which Nodes the Pods are scheduled on.
+          displayName: nodeSelect
+          path: nodeSelector
+        - description: Ember CSI driver container image to use
+          displayName: image
+          path: image
+        - description: Config for Ember
+          displayName: config
+          path: config
+        - description: Tolerations
+          displayName: tolerations
+          path: tolerations
+        - description: Topologies
+          displayName: topologies
+          path: topologies
+        # BEGIN AUTO GENERATED CONFIGURATION OPTIONS
+        - description: The type of storage backend
+          displayName: Driver
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:DriverSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:ZadaraVPSAISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:XtremIOISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:XtremIOFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:WindowsSmbfs'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:WindowsISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:VxFlexOS'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:VZStorage'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:VNX'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:VMwareVcVmdk'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:VMwareVStorageObject'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:Unity'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:SynoISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:StorwizeSVCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:StorwizeSVCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:StorPool'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:SolidFire'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:Sheepdog'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:SPDK'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:SCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:SCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:RSD'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:RBD'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:Quobyte'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:QnapISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:PureISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:PureFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:PowerMaxISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:PowerMaxFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:PSSeriesISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:NetAppCmodeISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:NetAppCmodeFibreChannel'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:MStorageISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:MStorageFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:LinstorIscsi'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:LinstorDrbd'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:LenovoISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:LenovoFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:KaminarioISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:InfortrendCLIISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:InfortrendCLIFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:InStorageMCSISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:InStorageMCSFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:IBMStorage'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:HuaweiISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:HuaweiFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:HedvigISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:HPMSAISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:HPMSAFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:HPELeftHandISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:HPE3PARISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:HPE3PARFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:GPFSRemote'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:GPFS'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:FlashSystemISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:FlashSystemFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:FJDXISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:FJDXFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:AS13000'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:ACCESSIscsi'
+        - description: "Va Config File."
+          displayName: Vrts Target Config
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vrts_target_config
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:ACCESSIscsiOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:ACCESSIscsi'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Create Sparse Lun."
+          displayName: Vrts Lun Sparse
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vrts_lun_sparse
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:ACCESSIscsiOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:ACCESSIscsi'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Pool Which Is Used As A Meta Pool When Creating A Volume, And It Should Be A Replication Pool At Present. If Not Set, The Driver Will Choose A Replication Pool From The Value Of As13000_Ipsan_Pools."
+          displayName: As13000 Meta Pool
+          path: config.envVars.X_CSI_BACKEND_CONFIG.as13000_meta_pool
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AS13000Options'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:AS13000'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Storage Pools Cinder Should Use, A Comma Separated List. [ie: v1,v2]"
+          displayName: As13000 Ipsan Pools
+          path: config.envVars.X_CSI_BACKEND_CONFIG.as13000_ipsan_pools__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AS13000Options'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:AS13000'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Effective Time Of Token Validity In Seconds. (min=600, max=3600)"
+          displayName: As13000 Token Available Time
+          path: config.envVars.X_CSI_BACKEND_CONFIG.as13000_token_available_time
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AS13000Options'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:AS13000'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Config File For Cinder Eternus_Dx Volume Driver."
+          displayName: Cinder Eternus Config File
+          path: config.envVars.X_CSI_BACKEND_CONFIG.cinder_eternus_config_file
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:FJDXFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:FJDXFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Config File For Cinder Eternus_Dx Volume Driver."
+          displayName: Cinder Eternus Config File
+          path: config.envVars.X_CSI_BACKEND_CONFIG.cinder_eternus_config_file
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:FJDXISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:FJDXISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Connection Protocol Should Be Fc. (Default Is Fc.)"
+          displayName: Flashsystem Connection Protocol
+          path: config.envVars.X_CSI_BACKEND_CONFIG.flashsystem_connection_protocol
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:FlashSystemFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:FlashSystemFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Allows Vdisk To Multi Host Mapping. (Default Is True)"
+          displayName: Flashsystem Multihostmap Enabled
+          path: config.envVars.X_CSI_BACKEND_CONFIG.flashsystem_multihostmap_enabled
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:FlashSystemFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:FlashSystemFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Connection Protocol Should Be Fc. (Default Is Fc.)"
+          displayName: Flashsystem Connection Protocol
+          path: config.envVars.X_CSI_BACKEND_CONFIG.flashsystem_connection_protocol
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:FlashSystemISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:FlashSystemISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Allows Vdisk To Multi Host Mapping. (Default Is True)"
+          displayName: Flashsystem Multihostmap Enabled
+          path: config.envVars.X_CSI_BACKEND_CONFIG.flashsystem_multihostmap_enabled
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:FlashSystemISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:FlashSystemISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies That Volumes Are Created As Sparse Files Which Initially Consume No Space. If Set To False, The Volume Is Created As A Fully Allocated File, In Which Case, Creation May Take A Significantly Longer Time."
+          displayName: Gpfs Sparse Volumes
+          path: config.envVars.X_CSI_BACKEND_CONFIG.gpfs_sparse_volumes
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:GPFSOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:GPFS'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies The Storage Pool That Volumes Are Assigned To. By Default, The System Storage Pool Is Used."
+          displayName: Gpfs Storage Pool
+          path: config.envVars.X_CSI_BACKEND_CONFIG.gpfs_storage_pool
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:GPFSOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:GPFS'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies An Upper Limit On The Number Of Indirections Required To Reach A Specific Block Due To Snapshots Or Clones.  A Lengthy Chain Of Copy-On-Write Snapshots Or Clones Can Have A Negative Impact On Performance, But Improves Space Utilization.  0 Indicates Unlimited Clone Depth."
+          displayName: Gpfs Max Clone Depth
+          path: config.envVars.X_CSI_BACKEND_CONFIG.gpfs_max_clone_depth
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:GPFSOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:GPFS'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies The Path Of The Gpfs Directory Where Block Storage Volume And Snapshot Files Are Stored."
+          displayName: Gpfs Mount Point Base
+          path: config.envVars.X_CSI_BACKEND_CONFIG.gpfs_mount_point_base
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:GPFSOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:GPFS'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies The Path Of The Image Service Repository In Gpfs.  Leave Undefined If Not Storing Images In Gpfs."
+          displayName: Gpfs Images Dir
+          path: config.envVars.X_CSI_BACKEND_CONFIG.gpfs_images_dir
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:GPFSOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:GPFS'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies The Type Of Image Copy To Be Used.  Set This When The Image Service Repository Also Uses Gpfs So That Image Files Can Be Transferred Efficiently From The Image Service To The Block Storage Service. There Are Two Valid Values: 'Copy' Specifies That A Full Copy Of The Image Is Made; 'Copy_On_Write' Specifies That Copy-On-Write Optimization Strategy Is Used And Unmodified Blocks Of The Image File Are Shared Efficiently."
+          displayName: Gpfs Images Share Mode
+          path: config.envVars.X_CSI_BACKEND_CONFIG.gpfs_images_share_mode__transform_empty_none
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:GPFSOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:copy'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:copy_on_write'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:GPFS'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies That Volumes Are Created As Sparse Files Which Initially Consume No Space. If Set To False, The Volume Is Created As A Fully Allocated File, In Which Case, Creation May Take A Significantly Longer Time."
+          displayName: Gpfs Sparse Volumes
+          path: config.envVars.X_CSI_BACKEND_CONFIG.gpfs_sparse_volumes
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:GPFSRemoteOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:GPFSRemote'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Filename Of Private Key To Use For Ssh Authentication."
+          displayName: Gpfs Private Key
+          path: config.envVars.X_CSI_BACKEND_CONFIG.gpfs_private_key
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:GPFSRemoteOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:GPFSRemote'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies The Storage Pool That Volumes Are Assigned To. By Default, The System Storage Pool Is Used."
+          displayName: Gpfs Storage Pool
+          path: config.envVars.X_CSI_BACKEND_CONFIG.gpfs_storage_pool
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:GPFSRemoteOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:GPFSRemote'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies An Upper Limit On The Number Of Indirections Required To Reach A Specific Block Due To Snapshots Or Clones.  A Lengthy Chain Of Copy-On-Write Snapshots Or Clones Can Have A Negative Impact On Performance, But Improves Space Utilization.  0 Indicates Unlimited Clone Depth."
+          displayName: Gpfs Max Clone Depth
+          path: config.envVars.X_CSI_BACKEND_CONFIG.gpfs_max_clone_depth
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:GPFSRemoteOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:GPFSRemote'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Username For Gpfs Nodes."
+          displayName: Gpfs User Login
+          path: config.envVars.X_CSI_BACKEND_CONFIG.gpfs_user_login
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:GPFSRemoteOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:GPFSRemote'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "File Containing Ssh Host Keys For The Gpfs Nodes With Which Driver Needs To Communicate. Default=$State_Path/Ssh_Known_Hosts"
+          displayName: Gpfs Hosts Key File
+          path: config.envVars.X_CSI_BACKEND_CONFIG.gpfs_hosts_key_file
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:GPFSRemoteOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:GPFSRemote'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Comma-Separated List Of Ip Address Or Hostnames Of Gpfs Nodes. [ie: v1,v2]"
+          displayName: Gpfs Hosts
+          path: config.envVars.X_CSI_BACKEND_CONFIG.gpfs_hosts__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:GPFSRemoteOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:GPFSRemote'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Password For Gpfs Node User."
+          displayName: Gpfs User Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.gpfs_user_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:GPFSRemoteOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:GPFSRemote'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Option To Enable Strict Gpfs Host Key Checking While Connecting To Gpfs Nodes. Default=False"
+          displayName: Gpfs Strict Host Key Policy
+          path: config.envVars.X_CSI_BACKEND_CONFIG.gpfs_strict_host_key_policy
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:GPFSRemoteOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:GPFSRemote'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies The Path Of The Gpfs Directory Where Block Storage Volume And Snapshot Files Are Stored."
+          displayName: Gpfs Mount Point Base
+          path: config.envVars.X_CSI_BACKEND_CONFIG.gpfs_mount_point_base
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:GPFSRemoteOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:GPFSRemote'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Ssh Port To Use. (min=0, max=65535)"
+          displayName: Gpfs Ssh Port
+          path: config.envVars.X_CSI_BACKEND_CONFIG.gpfs_ssh_port
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:GPFSRemoteOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:GPFSRemote'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies The Path Of The Image Service Repository In Gpfs.  Leave Undefined If Not Storing Images In Gpfs."
+          displayName: Gpfs Images Dir
+          path: config.envVars.X_CSI_BACKEND_CONFIG.gpfs_images_dir
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:GPFSRemoteOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:GPFSRemote'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies The Type Of Image Copy To Be Used.  Set This When The Image Service Repository Also Uses Gpfs So That Image Files Can Be Transferred Efficiently From The Image Service To The Block Storage Service. There Are Two Valid Values: 'Copy' Specifies That A Full Copy Of The Image Is Made; 'Copy_On_Write' Specifies That Copy-On-Write Optimization Strategy Is Used And Unmodified Blocks Of The Image File Are Shared Efficiently."
+          displayName: Gpfs Images Share Mode
+          path: config.envVars.X_CSI_BACKEND_CONFIG.gpfs_images_share_mode__transform_empty_none
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:GPFSRemoteOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:copy'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:copy_on_write'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:GPFSRemote'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The 3Par / Primera Cpg To Use For Snapshots Of Volumes. If Empty The Usercpg Will Be Used."
+          displayName: Hpe3Par Cpg Snap
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpe3par_cpg_snap
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Ssh Port To Use With San"
+          displayName: San Ssh Port
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_ssh_port
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Password For San Controller"
+          displayName: San Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Enable Http Debugging To 3Par / Primera"
+          displayName: Hpe3Par Debug
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpe3par_debug
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Ip Address Of San Controller"
+          displayName: San Ip
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_ip
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "3Par / Primera Password For The User Specified In Hpe3Par_Username"
+          displayName: Hpe3Par Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpe3par_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "List Of Target Iscsi Addresses To Use. [ie: v1,v2]"
+          displayName: Hpe3Par Iscsi Ips
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpe3par_iscsi_ips__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Time In Hours When A Snapshot Expires  And Is Deleted.  This Must Be Larger Than Expiration"
+          displayName: Hpe3Par Snapshot Expiration
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpe3par_snapshot_expiration
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "3Par / Primera Username With The 'Edit' Role"
+          displayName: Hpe3Par Username
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpe3par_username
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Filename Of Private Key To Use For Ssh Authentication"
+          displayName: San Private Key
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_private_key
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Port That The Iscsi Daemon Is Listening On (min=0, max=65535)"
+          displayName: Target Port
+          path: config.envVars.X_CSI_BACKEND_CONFIG.target_port
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Wsapi Server Url. This Setting Applies To Both 3Par And Primera. .       Example 1: For 3Par, Url Is: .       Https://<3Par Ip>:8080/Api/V1 .       Example 2: For Primera, Url Is: .       Https://<Primera Ip>:443/Api/V1"
+          displayName: Hpe3Par Api Url
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpe3par_api_url
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Username For San Controller"
+          displayName: San Login
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_login
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Ip Address That The Iscsi Daemon Is Listening On"
+          displayName: Target Ip Address
+          path: config.envVars.X_CSI_BACKEND_CONFIG.target_ip_address
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "List Of The 3Par / Primera Cpg(S) To Use For Volume Creation [ie: v1,v2]"
+          displayName: Hpe3Par Cpg
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpe3par_cpg__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Enable Chap Authentication For Iscsi Connections."
+          displayName: Hpe3Par Iscsi Chap Enabled
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpe3par_iscsi_chap_enabled
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Time In Hours To Retain A Snapshot.  You Can'T Delete It Before This Expires."
+          displayName: Hpe3Par Snapshot Retention
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpe3par_snapshot_retention
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Ssh Connection Timeout In Seconds"
+          displayName: Ssh Conn Timeout
+          path: config.envVars.X_CSI_BACKEND_CONFIG.ssh_conn_timeout
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Nsp Of 3Par Backend To Be Used When: (1) Multipath Is Not Enabled In Cinder.Conf. (2) Fiber Channel Zone Manager Is Not Used. (3) The 3Par Backend Is Prezoned With This Specific Nsp Only. For Example If Nsp Is 2 1 2, The Format Of The Option'S Value Is 2:1:2"
+          displayName: Hpe3Par Target Nsp
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpe3par_target_nsp
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The 3Par / Primera Cpg To Use For Snapshots Of Volumes. If Empty The Usercpg Will Be Used."
+          displayName: Hpe3Par Cpg Snap
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpe3par_cpg_snap
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Ssh Port To Use With San"
+          displayName: San Ssh Port
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_ssh_port
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Password For San Controller"
+          displayName: San Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Enable Http Debugging To 3Par / Primera"
+          displayName: Hpe3Par Debug
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpe3par_debug
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Ip Address Of San Controller"
+          displayName: San Ip
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_ip
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "3Par / Primera Password For The User Specified In Hpe3Par_Username"
+          displayName: Hpe3Par Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpe3par_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "List Of Target Iscsi Addresses To Use. [ie: v1,v2]"
+          displayName: Hpe3Par Iscsi Ips
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpe3par_iscsi_ips__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Time In Hours When A Snapshot Expires  And Is Deleted.  This Must Be Larger Than Expiration"
+          displayName: Hpe3Par Snapshot Expiration
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpe3par_snapshot_expiration
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "3Par / Primera Username With The 'Edit' Role"
+          displayName: Hpe3Par Username
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpe3par_username
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Filename Of Private Key To Use For Ssh Authentication"
+          displayName: San Private Key
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_private_key
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Port That The Iscsi Daemon Is Listening On (min=0, max=65535)"
+          displayName: Target Port
+          path: config.envVars.X_CSI_BACKEND_CONFIG.target_port
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Wsapi Server Url. This Setting Applies To Both 3Par And Primera. .       Example 1: For 3Par, Url Is: .       Https://<3Par Ip>:8080/Api/V1 .       Example 2: For Primera, Url Is: .       Https://<Primera Ip>:443/Api/V1"
+          displayName: Hpe3Par Api Url
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpe3par_api_url
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Username For San Controller"
+          displayName: San Login
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_login
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Ip Address That The Iscsi Daemon Is Listening On"
+          displayName: Target Ip Address
+          path: config.envVars.X_CSI_BACKEND_CONFIG.target_ip_address
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "List Of The 3Par / Primera Cpg(S) To Use For Volume Creation [ie: v1,v2]"
+          displayName: Hpe3Par Cpg
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpe3par_cpg__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Enable Chap Authentication For Iscsi Connections."
+          displayName: Hpe3Par Iscsi Chap Enabled
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpe3par_iscsi_chap_enabled
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Time In Hours To Retain A Snapshot.  You Can'T Delete It Before This Expires."
+          displayName: Hpe3Par Snapshot Retention
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpe3par_snapshot_retention
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Ssh Connection Timeout In Seconds"
+          displayName: Ssh Conn Timeout
+          path: config.envVars.X_CSI_BACKEND_CONFIG.ssh_conn_timeout
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Nsp Of 3Par Backend To Be Used When: (1) Multipath Is Not Enabled In Cinder.Conf. (2) Fiber Channel Zone Manager Is Not Used. (3) The 3Par Backend Is Prezoned With This Specific Nsp Only. For Example If Nsp Is 2 1 2, The Format Of The Option'S Value Is 2:1:2"
+          displayName: Hpe3Par Target Nsp
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpe3par_target_nsp
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPE3PARISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPE3PARISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Port Number Of Ssh Service. (min=0, max=65535)"
+          displayName: Hpelefthand Ssh Port
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpelefthand_ssh_port
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPELeftHandISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPELeftHandISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Hpe Lefthand Super User Password"
+          displayName: Hpelefthand Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpelefthand_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPELeftHandISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPELeftHandISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Configure Chap Authentication For Iscsi Connections (Default: Disabled)"
+          displayName: Hpelefthand Iscsi Chap Enabled
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpelefthand_iscsi_chap_enabled
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPELeftHandISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPELeftHandISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Enable Http Debugging To Lefthand"
+          displayName: Hpelefthand Debug
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpelefthand_debug
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPELeftHandISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPELeftHandISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Hpe Lefthand Cluster Name"
+          displayName: Hpelefthand Clustername
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpelefthand_clustername
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPELeftHandISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPELeftHandISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Hpe Lefthand Super User Username"
+          displayName: Hpelefthand Username
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpelefthand_username
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPELeftHandISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPELeftHandISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Hpe Lefthand Wsapi Server Url Like Https://<Lefthand Ip>:8081/Lhos"
+          displayName: Hpelefthand Api Url
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpelefthand_api_url
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPELeftHandISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPELeftHandISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Pool Or Vdisk Name To Use For Volume Creation."
+          displayName: Hpmsa Pool Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpmsa_pool_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPMSAFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPMSAFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Linear (For Vdisk) Or Virtual (For Pool)."
+          displayName: Hpmsa Pool Type
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpmsa_pool_type
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPMSAFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:linear'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:virtual'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPMSAFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Linear (For Vdisk) Or Virtual (For Pool)."
+          displayName: Hpmsa Pool Type
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpmsa_pool_type
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPMSAISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:linear'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:virtual'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPMSAISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "List Of Comma-Separated Target Iscsi Ip Addresses. [ie: v1,v2]"
+          displayName: Hpmsa Iscsi Ips
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpmsa_iscsi_ips__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPMSAISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPMSAISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Pool Or Vdisk Name To Use For Volume Creation."
+          displayName: Hpmsa Pool Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hpmsa_pool_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HPMSAISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HPMSAISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Remote Metro Device Request Url."
+          displayName: Metro San Address
+          path: config.envVars.X_CSI_BACKEND_CONFIG.metro_san_address
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HuaweiFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HuaweiFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Remote Metro Device Domain Name."
+          displayName: Metro Domain Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.metro_domain_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HuaweiFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HuaweiFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Remote Device Hypermetro Will Use."
+          displayName: Hypermetro Devices
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hypermetro_devices
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HuaweiFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HuaweiFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Remote Metro Device Pool Names."
+          displayName: Metro Storage Pools
+          path: config.envVars.X_CSI_BACKEND_CONFIG.metro_storage_pools
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HuaweiFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HuaweiFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Configuration File For The Cinder Huawei Driver."
+          displayName: Cinder Huawei Conf File
+          path: config.envVars.X_CSI_BACKEND_CONFIG.cinder_huawei_conf_file
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HuaweiFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HuaweiFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Remote Metro Device San Password."
+          displayName: Metro San Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.metro_san_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HuaweiFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HuaweiFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Remote Metro Device San User."
+          displayName: Metro San User
+          path: config.envVars.X_CSI_BACKEND_CONFIG.metro_san_user
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HuaweiFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HuaweiFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Remote Metro Device Request Url."
+          displayName: Metro San Address
+          path: config.envVars.X_CSI_BACKEND_CONFIG.metro_san_address
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HuaweiISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HuaweiISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Remote Metro Device Domain Name."
+          displayName: Metro Domain Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.metro_domain_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HuaweiISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HuaweiISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Remote Device Hypermetro Will Use."
+          displayName: Hypermetro Devices
+          path: config.envVars.X_CSI_BACKEND_CONFIG.hypermetro_devices
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HuaweiISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HuaweiISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Remote Metro Device Pool Names."
+          displayName: Metro Storage Pools
+          path: config.envVars.X_CSI_BACKEND_CONFIG.metro_storage_pools
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HuaweiISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HuaweiISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Configuration File For The Cinder Huawei Driver."
+          displayName: Cinder Huawei Conf File
+          path: config.envVars.X_CSI_BACKEND_CONFIG.cinder_huawei_conf_file
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HuaweiISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HuaweiISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Remote Metro Device San Password."
+          displayName: Metro San Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.metro_san_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HuaweiISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HuaweiISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Remote Metro Device San User."
+          displayName: Metro San User
+          path: config.envVars.X_CSI_BACKEND_CONFIG.metro_san_user
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:HuaweiISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:HuaweiISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Connection Type To The Ibm Storage Array"
+          displayName: Connection Type
+          path: config.envVars.X_CSI_BACKEND_CONFIG.connection_type
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:IBMStorageOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:fibre_channel'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:iscsi'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:IBMStorage'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "List Of Management Ip Addresses (Separated By Commas)"
+          displayName: Management Ips
+          path: config.envVars.X_CSI_BACKEND_CONFIG.management_ips
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:IBMStorageOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:IBMStorage'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Chap Authentication Mode, Effective Only For Iscsi (Disabled|Enabled)"
+          displayName: Chap
+          path: config.envVars.X_CSI_BACKEND_CONFIG.chap
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:IBMStorageOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:disabled'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:enabled'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:IBMStorage'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Proxy Driver That Connects To The Ibm Storage Array"
+          displayName: Proxy
+          path: config.envVars.X_CSI_BACKEND_CONFIG.proxy
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:IBMStorageOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:IBMStorage'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Storage System Space-Efficiency Parameter For Volumes (Percentage) (min=-1, max=100)"
+          displayName: Instorage Mcs Vol Rsize
+          path: config.envVars.X_CSI_BACKEND_CONFIG.instorage_mcs_vol_rsize
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InStorageMCSFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InStorageMCSFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Maximum Number Of Seconds To Wait For Localcopy To Be Prepared. (min=1, max=600)"
+          displayName: Instorage Mcs Localcopy Timeout
+          path: config.envVars.X_CSI_BACKEND_CONFIG.instorage_mcs_localcopy_timeout
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InStorageMCSFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InStorageMCSFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies The Instorage Localcopy Copy Rate To Be Used When Creating A Full Volume Copy. The Default Is Rate Is 50, And The Valid Rates Are 1-100. (min=1, max=100)"
+          displayName: Instorage Mcs Localcopy Rate
+          path: config.envVars.X_CSI_BACKEND_CONFIG.instorage_mcs_localcopy_rate
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InStorageMCSFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InStorageMCSFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Storage System Autoexpand Parameter For Volumes (True/False)"
+          displayName: Instorage Mcs Vol Autoexpand
+          path: config.envVars.X_CSI_BACKEND_CONFIG.instorage_mcs_vol_autoexpand
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InStorageMCSFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InStorageMCSFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Storage System Threshold For Volume Capacity Warnings (Percentage) (min=-1, max=100)"
+          displayName: Instorage Mcs Vol Warning
+          path: config.envVars.X_CSI_BACKEND_CONFIG.instorage_mcs_vol_warning
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InStorageMCSFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InStorageMCSFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Storage System Grain Size Parameter For Volumes (32/64/128/256) (min=32, max=256)"
+          displayName: Instorage Mcs Vol Grainsize
+          path: config.envVars.X_CSI_BACKEND_CONFIG.instorage_mcs_vol_grainsize
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InStorageMCSFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InStorageMCSFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies Secondary Management Ip Or Hostname To Be Used If San_Ip Is Invalid Or Becomes Inaccessible."
+          displayName: Instorage San Secondary Ip
+          path: config.envVars.X_CSI_BACKEND_CONFIG.instorage_san_secondary_ip
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InStorageMCSFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InStorageMCSFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Allow Tenants To Specify Qos On Create"
+          displayName: Instorage Mcs Allow Tenant Qos
+          path: config.envVars.X_CSI_BACKEND_CONFIG.instorage_mcs_allow_tenant_qos
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InStorageMCSFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InStorageMCSFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Enable Intier For Volumes"
+          displayName: Instorage Mcs Vol Intier
+          path: config.envVars.X_CSI_BACKEND_CONFIG.instorage_mcs_vol_intier
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InStorageMCSFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InStorageMCSFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The I/O Group In Which To Allocate Volumes. It Can Be A Comma-Separated List In Which Case The Driver Will Select An Io_Group Based On Least Number Of Volumes Associated With The Io_Group."
+          displayName: Instorage Mcs Vol Iogrp
+          path: config.envVars.X_CSI_BACKEND_CONFIG.instorage_mcs_vol_iogrp
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InStorageMCSFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InStorageMCSFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Storage System Compression Option For Volumes"
+          displayName: Instorage Mcs Vol Compression
+          path: config.envVars.X_CSI_BACKEND_CONFIG.instorage_mcs_vol_compression
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InStorageMCSFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InStorageMCSFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Comma Separated List Of Storage System Storage Pools For Volumes. [ie: v1,v2]"
+          displayName: Instorage Mcs Volpool Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.instorage_mcs_volpool_name__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InStorageMCSFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InStorageMCSFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Storage System Space-Efficiency Parameter For Volumes (Percentage) (min=-1, max=100)"
+          displayName: Instorage Mcs Vol Rsize
+          path: config.envVars.X_CSI_BACKEND_CONFIG.instorage_mcs_vol_rsize
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InStorageMCSISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InStorageMCSISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Maximum Number Of Seconds To Wait For Localcopy To Be Prepared. (min=1, max=600)"
+          displayName: Instorage Mcs Localcopy Timeout
+          path: config.envVars.X_CSI_BACKEND_CONFIG.instorage_mcs_localcopy_timeout
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InStorageMCSISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InStorageMCSISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies The Instorage Localcopy Copy Rate To Be Used When Creating A Full Volume Copy. The Default Is Rate Is 50, And The Valid Rates Are 1-100. (min=1, max=100)"
+          displayName: Instorage Mcs Localcopy Rate
+          path: config.envVars.X_CSI_BACKEND_CONFIG.instorage_mcs_localcopy_rate
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InStorageMCSISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InStorageMCSISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Storage System Autoexpand Parameter For Volumes (True/False)"
+          displayName: Instorage Mcs Vol Autoexpand
+          path: config.envVars.X_CSI_BACKEND_CONFIG.instorage_mcs_vol_autoexpand
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InStorageMCSISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InStorageMCSISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Storage System Threshold For Volume Capacity Warnings (Percentage) (min=-1, max=100)"
+          displayName: Instorage Mcs Vol Warning
+          path: config.envVars.X_CSI_BACKEND_CONFIG.instorage_mcs_vol_warning
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InStorageMCSISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InStorageMCSISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Storage System Grain Size Parameter For Volumes (32/64/128/256) (min=32, max=256)"
+          displayName: Instorage Mcs Vol Grainsize
+          path: config.envVars.X_CSI_BACKEND_CONFIG.instorage_mcs_vol_grainsize
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InStorageMCSISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InStorageMCSISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies Secondary Management Ip Or Hostname To Be Used If San_Ip Is Invalid Or Becomes Inaccessible."
+          displayName: Instorage San Secondary Ip
+          path: config.envVars.X_CSI_BACKEND_CONFIG.instorage_san_secondary_ip
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InStorageMCSISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InStorageMCSISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Allow Tenants To Specify Qos On Create"
+          displayName: Instorage Mcs Allow Tenant Qos
+          path: config.envVars.X_CSI_BACKEND_CONFIG.instorage_mcs_allow_tenant_qos
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InStorageMCSISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InStorageMCSISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Enable Intier For Volumes"
+          displayName: Instorage Mcs Vol Intier
+          path: config.envVars.X_CSI_BACKEND_CONFIG.instorage_mcs_vol_intier
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InStorageMCSISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InStorageMCSISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The I/O Group In Which To Allocate Volumes. It Can Be A Comma-Separated List In Which Case The Driver Will Select An Io_Group Based On Least Number Of Volumes Associated With The Io_Group."
+          displayName: Instorage Mcs Vol Iogrp
+          path: config.envVars.X_CSI_BACKEND_CONFIG.instorage_mcs_vol_iogrp
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InStorageMCSISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InStorageMCSISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Storage System Compression Option For Volumes"
+          displayName: Instorage Mcs Vol Compression
+          path: config.envVars.X_CSI_BACKEND_CONFIG.instorage_mcs_vol_compression
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InStorageMCSISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InStorageMCSISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Comma Separated List Of Storage System Storage Pools For Volumes. [ie: v1,v2]"
+          displayName: Instorage Mcs Volpool Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.instorage_mcs_volpool_name__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InStorageMCSISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InStorageMCSISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Infortrend Raid Channel Id List On Slot B For Openstack Usage. It Is Separated With Comma. [ie: v1,v2]"
+          displayName: Infortrend Slots B Channels Id
+          path: config.envVars.X_CSI_BACKEND_CONFIG.infortrend_slots_b_channels_id__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InfortrendCLIFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InfortrendCLIFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Timeout For Cli In Seconds."
+          displayName: Infortrend Cli Timeout
+          path: config.envVars.X_CSI_BACKEND_CONFIG.infortrend_cli_timeout
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InfortrendCLIFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InfortrendCLIFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Infortrend Cli Absolute Path."
+          displayName: Infortrend Cli Path
+          path: config.envVars.X_CSI_BACKEND_CONFIG.infortrend_cli_path
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InfortrendCLIFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InfortrendCLIFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Infortrend Cli Cache. While Set True, The Raid Status Report Will Use Cache Stored In The Cli. Never Enable This Unless The Raid Is Managed Only By Openstack And Only By One Infortrend Cinder-Volume Backend. Otherwise, Cli Might Report Out-Dated Status To Cinder And Thus There Might Be Some Race Condition Among All Backend/Clis."
+          displayName: Infortrend Cli Cache
+          path: config.envVars.X_CSI_BACKEND_CONFIG.infortrend_cli_cache
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InfortrendCLIFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InfortrendCLIFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Infortrend Raid Channel Id List On Slot A For Openstack Usage. It Is Separated With Comma. [ie: v1,v2]"
+          displayName: Infortrend Slots A Channels Id
+          path: config.envVars.X_CSI_BACKEND_CONFIG.infortrend_slots_a_channels_id__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InfortrendCLIFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InfortrendCLIFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Infortrend Logical Volumes Name List. It Is Separated With Comma. [ie: v1,v2]"
+          displayName: Infortrend Pools Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.infortrend_pools_name__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InfortrendCLIFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InfortrendCLIFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Java Absolute Path."
+          displayName: Java Path
+          path: config.envVars.X_CSI_BACKEND_CONFIG.java_path
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InfortrendCLIFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InfortrendCLIFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Maximum Retry Times If A Command Fails."
+          displayName: Infortrend Cli Max Retries
+          path: config.envVars.X_CSI_BACKEND_CONFIG.infortrend_cli_max_retries
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InfortrendCLIFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InfortrendCLIFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Infortrend Iqn Prefix For Iscsi."
+          displayName: Infortrend Iqn Prefix
+          path: config.envVars.X_CSI_BACKEND_CONFIG.infortrend_iqn_prefix
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InfortrendCLIFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InfortrendCLIFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Infortrend Raid Channel Id List On Slot B For Openstack Usage. It Is Separated With Comma. [ie: v1,v2]"
+          displayName: Infortrend Slots B Channels Id
+          path: config.envVars.X_CSI_BACKEND_CONFIG.infortrend_slots_b_channels_id__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InfortrendCLIISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InfortrendCLIISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Timeout For Cli In Seconds."
+          displayName: Infortrend Cli Timeout
+          path: config.envVars.X_CSI_BACKEND_CONFIG.infortrend_cli_timeout
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InfortrendCLIISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InfortrendCLIISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Infortrend Cli Absolute Path."
+          displayName: Infortrend Cli Path
+          path: config.envVars.X_CSI_BACKEND_CONFIG.infortrend_cli_path
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InfortrendCLIISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InfortrendCLIISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Infortrend Cli Cache. While Set True, The Raid Status Report Will Use Cache Stored In The Cli. Never Enable This Unless The Raid Is Managed Only By Openstack And Only By One Infortrend Cinder-Volume Backend. Otherwise, Cli Might Report Out-Dated Status To Cinder And Thus There Might Be Some Race Condition Among All Backend/Clis."
+          displayName: Infortrend Cli Cache
+          path: config.envVars.X_CSI_BACKEND_CONFIG.infortrend_cli_cache
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InfortrendCLIISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InfortrendCLIISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Infortrend Raid Channel Id List On Slot A For Openstack Usage. It Is Separated With Comma. [ie: v1,v2]"
+          displayName: Infortrend Slots A Channels Id
+          path: config.envVars.X_CSI_BACKEND_CONFIG.infortrend_slots_a_channels_id__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InfortrendCLIISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InfortrendCLIISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Infortrend Logical Volumes Name List. It Is Separated With Comma. [ie: v1,v2]"
+          displayName: Infortrend Pools Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.infortrend_pools_name__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InfortrendCLIISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InfortrendCLIISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Java Absolute Path."
+          displayName: Java Path
+          path: config.envVars.X_CSI_BACKEND_CONFIG.java_path
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InfortrendCLIISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InfortrendCLIISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Maximum Retry Times If A Command Fails."
+          displayName: Infortrend Cli Max Retries
+          path: config.envVars.X_CSI_BACKEND_CONFIG.infortrend_cli_max_retries
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InfortrendCLIISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InfortrendCLIISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Infortrend Iqn Prefix For Iscsi."
+          displayName: Infortrend Iqn Prefix
+          path: config.envVars.X_CSI_BACKEND_CONFIG.infortrend_iqn_prefix
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:InfortrendCLIISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:InfortrendCLIISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Password For San Controller"
+          displayName: San Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:KaminarioISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:KaminarioISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Username For San Controller"
+          displayName: San Login
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_login
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:KaminarioISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:KaminarioISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Disabling Iscsi Discovery (Sendtargets) For Multipath Connections On K2 Driver."
+          displayName: Disable Discovery
+          path: config.envVars.X_CSI_BACKEND_CONFIG.disable_discovery
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:KaminarioISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:KaminarioISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Default Block Size Used When Copying/Clearing Volumes"
+          displayName: Volume Dd Blocksize
+          path: config.envVars.X_CSI_BACKEND_CONFIG.volume_dd_blocksize
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:KaminarioISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:KaminarioISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Ip Address Of San Controller"
+          displayName: San Ip
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_ip
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:KaminarioISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:KaminarioISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Whether Or Not Our Private Network Has Unique Fqdn On Each Initiator Or Not.  For Example Networks With Qa Systems Usually Have Multiple Servers/Vms With The Same Fqdn.  When True This Will Create Host Entries On K2 Using The Fqdn, When False It Will Use The Reversed Iqn/Wwnn."
+          displayName: Unique Fqdn Network
+          path: config.envVars.X_CSI_BACKEND_CONFIG.unique_fqdn_network
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:KaminarioISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:KaminarioISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Volume Configuration File Storage Directory"
+          displayName: Volumes Dir
+          path: config.envVars.X_CSI_BACKEND_CONFIG.volumes_dir
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LVMVolumeOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "If >0, Create Lvs With Multiple Mirrors. Note That This Requires Lvm_Mirrors + 2 Pvs With Available Space"
+          displayName: Lvm Mirrors
+          path: config.envVars.X_CSI_BACKEND_CONFIG.lvm_mirrors
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LVMVolumeOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Nvme Target Remote Configuration Ip Address."
+          displayName: Spdk Rpc Ip
+          path: config.envVars.X_CSI_BACKEND_CONFIG.spdk_rpc_ip
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LVMVolumeOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Prefix For Iscsi Volumes"
+          displayName: Target Prefix
+          path: config.envVars.X_CSI_BACKEND_CONFIG.target_prefix
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LVMVolumeOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Queue Depth For Rdma Transport."
+          displayName: Spdk Max Queue Depth
+          path: config.envVars.X_CSI_BACKEND_CONFIG.spdk_max_queue_depth
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LVMVolumeOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Sets The Behavior Of The Iscsi Target To Either Perform Write-Back(On) Or Write-Through(Off). This Parameter Is Valid If Target_Helper Is Set To Tgtadm."
+          displayName: Iscsi Write Cache
+          path: config.envVars.X_CSI_BACKEND_CONFIG.iscsi_write_cache
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LVMVolumeOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:on'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:off'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Certain Iscsi Targets Have Predefined Target Names, Scst Target Driver Uses This Name."
+          displayName: Scst Target Iqn Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.scst_target_iqn_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LVMVolumeOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Ip Address That The Iscsi Daemon Is Listening On"
+          displayName: Target Ip Address
+          path: config.envVars.X_CSI_BACKEND_CONFIG.target_ip_address
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LVMVolumeOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Sets The Behavior Of The Iscsi Target To Either Perform Blockio Or Fileio Optionally, Auto Can Be Set And Cinder Will Autodetect Type Of Backing Device"
+          displayName: Iscsi Iotype
+          path: config.envVars.X_CSI_BACKEND_CONFIG.iscsi_iotype
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LVMVolumeOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:blockio'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:fileio'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:auto'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Suppress Leaked File Descriptor Warnings In Lvm Commands."
+          displayName: Lvm Suppress Fd Warnings
+          path: config.envVars.X_CSI_BACKEND_CONFIG.lvm_suppress_fd_warnings
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LVMVolumeOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Iet Configuration File"
+          displayName: Iet Conf
+          path: config.envVars.X_CSI_BACKEND_CONFIG.iet_conf
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LVMVolumeOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Nvme Target Remote Configuration Port."
+          displayName: Spdk Rpc Port
+          path: config.envVars.X_CSI_BACKEND_CONFIG.spdk_rpc_port
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LVMVolumeOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Name For The Vg That Will Contain Exported Volumes"
+          displayName: Volume Group
+          path: config.envVars.X_CSI_BACKEND_CONFIG.volume_group
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LVMVolumeOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The List Of Secondary Ip Addresses Of The Iscsi Daemon [ie: v1,v2]"
+          displayName: Iscsi Secondary Ip Addresses
+          path: config.envVars.X_CSI_BACKEND_CONFIG.iscsi_secondary_ip_addresses__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LVMVolumeOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Default Block Size Used When Copying/Clearing Volumes"
+          displayName: Volume Dd Blocksize
+          path: config.envVars.X_CSI_BACKEND_CONFIG.volume_dd_blocksize
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LVMVolumeOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Method Used To Wipe Old Volumes"
+          displayName: Volume Clear
+          path: config.envVars.X_CSI_BACKEND_CONFIG.volume_clear
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LVMVolumeOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:none'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:zero'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Type Of Lvm Volumes To Deploy; (Default, Thin, Or Auto). Auto Defaults To Thin If Thin Is Supported."
+          displayName: Lvm Type
+          path: config.envVars.X_CSI_BACKEND_CONFIG.lvm_type
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LVMVolumeOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:default'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:thin'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:auto'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Determines The Target Protocol For New Volumes, Created With Tgtadm, Lioadm And Nvmet Target Helpers. In Order To Enable Rdma, This Parameter Should Be Set With The Value 'Iser'. The Supported Iscsi Protocol Values Are 'Iscsi' And 'Iser', In Case Of Nvmet Target Set To 'Nvmet_Rdma'."
+          displayName: Target Protocol
+          path: config.envVars.X_CSI_BACKEND_CONFIG.target_protocol
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LVMVolumeOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:iscsi'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:iser'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:nvmet_rdma'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Target User-Land Tool To Use. Tgtadm Is Default, Use Lioadm For Lio Iscsi Support, Scstadmin For Scst Target Support, Ietadm For Iscsi Enterprise Target, Iscsictl For Chelsio Iscsi Target, Nvmet For Nvmeof Support, Spdk-Nvmeof For Spdk Nvme-Of, Or Fake For Testing."
+          displayName: Target Helper
+          path: config.envVars.X_CSI_BACKEND_CONFIG.target_helper
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LVMVolumeOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:tgtadm'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:lioadm'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:scstadmin'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:iscsictl'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:ietadm'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:nvmet'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:spdk-nvmeof'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:fake'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Lvm Conf File To Use For The Lvm Driver In Cinder; This Setting Is Ignored If The Specified File Does Not Exist (You Can Also Specify 'None' To Not Use A Conf File Even If One Exists)."
+          displayName: Lvm Conf File
+          path: config.envVars.X_CSI_BACKEND_CONFIG.lvm_conf_file
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LVMVolumeOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Scst Target Implementation Can Choose From Multiple Scst Target Drivers."
+          displayName: Scst Target Driver
+          path: config.envVars.X_CSI_BACKEND_CONFIG.scst_target_driver
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LVMVolumeOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Nvme Target Remote Configuration Password."
+          displayName: Spdk Rpc Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.spdk_rpc_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LVMVolumeOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Port That The Nvme Target Is Listening On."
+          displayName: Nvmet Port Id
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nvmet_port_id
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LVMVolumeOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Size In Mib To Wipe At Start Of Old Volumes. 1024 Mib At Max. 0 => All (max=1024)"
+          displayName: Volume Clear Size
+          path: config.envVars.X_CSI_BACKEND_CONFIG.volume_clear_size
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LVMVolumeOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Port That The Iscsi Daemon Is Listening On (min=0, max=65535)"
+          displayName: Target Port
+          path: config.envVars.X_CSI_BACKEND_CONFIG.target_port
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LVMVolumeOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Sets The Target-Specific Flags For The Iscsi Target. Only Used For Tgtadm To Specify Backing Device Flags Using Bsoflags Option. The Specified String Is Passed As Is To The Underlying Tool."
+          displayName: Iscsi Target Flags
+          path: config.envVars.X_CSI_BACKEND_CONFIG.iscsi_target_flags
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LVMVolumeOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Nvme Target Remote Configuration Username."
+          displayName: Spdk Rpc Username
+          path: config.envVars.X_CSI_BACKEND_CONFIG.spdk_rpc_username
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LVMVolumeOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LVMVolume'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Pool Or Vdisk Name To Use For Volume Creation."
+          displayName: Lenovo Pool Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.lenovo_pool_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LenovoFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LenovoFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Linear (For Vdisk) Or Virtual (For Pool)."
+          displayName: Lenovo Pool Type
+          path: config.envVars.X_CSI_BACKEND_CONFIG.lenovo_pool_type
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LenovoFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:linear'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:virtual'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LenovoFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Pool Or Vdisk Name To Use For Volume Creation."
+          displayName: Lenovo Pool Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.lenovo_pool_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LenovoISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LenovoISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "List Of Comma-Separated Target Iscsi Ip Addresses. [ie: v1,v2]"
+          displayName: Lenovo Iscsi Ips
+          path: config.envVars.X_CSI_BACKEND_CONFIG.lenovo_iscsi_ips__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LenovoISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LenovoISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Linear (For Vdisk) Or Virtual (For Pool)."
+          displayName: Lenovo Pool Type
+          path: config.envVars.X_CSI_BACKEND_CONFIG.lenovo_pool_type
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LenovoISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:linear'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:virtual'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LenovoISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "True Means Cinder Node Is A Diskless Linstor Node."
+          displayName: Linstor Controller Diskless
+          path: config.envVars.X_CSI_BACKEND_CONFIG.linstor_controller_diskless
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LinstorDrbdOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LinstorDrbd'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Default Block Size For Image Restoration. When Using Iscsi Transport, This Option Specifies The Block Size."
+          displayName: Linstor Default Blocksize
+          path: config.envVars.X_CSI_BACKEND_CONFIG.linstor_default_blocksize
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LinstorDrbdOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LinstorDrbd'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Default Storage Uri For Linstor."
+          displayName: Linstor Default Uri
+          path: config.envVars.X_CSI_BACKEND_CONFIG.linstor_default_uri
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LinstorDrbdOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LinstorDrbd'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Default Storage Pool Name For Linstor."
+          displayName: Linstor Default Storage Pool Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.linstor_default_storage_pool_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LinstorDrbdOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LinstorDrbd'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Default Volume Downscale Size In Kib = 4 Mib."
+          displayName: Linstor Volume Downsize Factor
+          path: config.envVars.X_CSI_BACKEND_CONFIG.linstor_volume_downsize_factor
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LinstorDrbdOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LinstorDrbd'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Default Volume Group Name For Linstor. Not Cinder Volume."
+          displayName: Linstor Default Volume Group Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.linstor_default_volume_group_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LinstorDrbdOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LinstorDrbd'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Autoplace Replication Count On Volume Deployment. 0 = Full Cluster Replication Without Autoplace, 1 = Single Node Deployment Without Replication, 2 Or Greater = Replicated Deployment With Autoplace."
+          displayName: Linstor Autoplace Count
+          path: config.envVars.X_CSI_BACKEND_CONFIG.linstor_autoplace_count
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LinstorDrbdOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LinstorDrbd'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "True Means Cinder Node Is A Diskless Linstor Node."
+          displayName: Linstor Controller Diskless
+          path: config.envVars.X_CSI_BACKEND_CONFIG.linstor_controller_diskless
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LinstorIscsiOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LinstorIscsi'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Default Block Size For Image Restoration. When Using Iscsi Transport, This Option Specifies The Block Size."
+          displayName: Linstor Default Blocksize
+          path: config.envVars.X_CSI_BACKEND_CONFIG.linstor_default_blocksize
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LinstorIscsiOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LinstorIscsi'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Default Storage Uri For Linstor."
+          displayName: Linstor Default Uri
+          path: config.envVars.X_CSI_BACKEND_CONFIG.linstor_default_uri
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LinstorIscsiOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LinstorIscsi'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Default Storage Pool Name For Linstor."
+          displayName: Linstor Default Storage Pool Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.linstor_default_storage_pool_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LinstorIscsiOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LinstorIscsi'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Default Volume Downscale Size In Kib = 4 Mib."
+          displayName: Linstor Volume Downsize Factor
+          path: config.envVars.X_CSI_BACKEND_CONFIG.linstor_volume_downsize_factor
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LinstorIscsiOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LinstorIscsi'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Default Volume Group Name For Linstor. Not Cinder Volume."
+          displayName: Linstor Default Volume Group Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.linstor_default_volume_group_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LinstorIscsiOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LinstorIscsi'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Autoplace Replication Count On Volume Deployment. 0 = Full Cluster Replication Without Autoplace, 1 = Single Node Deployment Without Replication, 2 Or Greater = Replicated Deployment With Autoplace."
+          displayName: Linstor Autoplace Count
+          path: config.envVars.X_CSI_BACKEND_CONFIG.linstor_autoplace_count
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:LinstorIscsiOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:LinstorIscsi'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "M-Series Storage Control Volume Name Format."
+          displayName: Nec Cv Ldname Format
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_cv_ldname_format
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "M-Series Storage Ld Name Format For Volumes."
+          displayName: Nec Ldname Format
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_ldname_format
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "User Name For M-Series Storage Ismcli."
+          displayName: Nec Ismcli User
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_ismcli_user
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "M-Series Storage Ld Set Name For Compute Node."
+          displayName: Nec Ldset
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_ldset
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "M-Series Storage Ld Name Format For Snapshots."
+          displayName: Nec Backup Ldname Format
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_backup_ldname_format
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Filename Of Rsa Private Key For M-Series Storage Ismcli."
+          displayName: Nec Ismcli Privkey
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_ismcli_privkey
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Port Number Of Ssh Pool."
+          displayName: Nec Ssh Pool Port Number
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_ssh_pool_port_number
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Fip Address Of M-Series Storage Ismcli."
+          displayName: Nec Ismcli Fip
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_ismcli_fip
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Use Legacy Ismcli Command."
+          displayName: Nec Queryconfig View
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_queryconfig_view
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Maximum Number Of Managing Sessions."
+          displayName: Nec Backend Max Ld Count
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_backend_max_ld_count
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Timeout Value Of Unpairthread."
+          displayName: Nec Unpairthread Timeout
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_unpairthread_timeout
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Configure Access Control Automatically."
+          displayName: Nec Auto Accesscontrol
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_auto_accesscontrol
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Use Legacy Ismcli Command With Optimization."
+          displayName: Nec Ismview Alloptimize
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_ismview_alloptimize
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Output Path Of Ismview File."
+          displayName: Nec Ismview Dir
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_ismview_dir
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Password For M-Series Storage Ismcli."
+          displayName: Nec Ismcli Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_ismcli_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Diskarray Name Of M-Series Storage."
+          displayName: Nec Diskarray Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_diskarray_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Return Actual Free Capacity."
+          displayName: Nec Actual Free Capacity
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_actual_free_capacity
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "M-Series Storage Backup Pool Number To Be Used. [ie: v1,v2]"
+          displayName: Nec Backup Pools
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_backup_pools__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "M-Series Storage Pool Numbers List To Be Used. [ie: v1,v2]"
+          displayName: Nec Pools
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_pools__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "M-Series Storage Control Volume Name Format."
+          displayName: Nec Cv Ldname Format
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_cv_ldname_format
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "M-Series Storage Ld Name Format For Volumes."
+          displayName: Nec Ldname Format
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_ldname_format
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "User Name For M-Series Storage Ismcli."
+          displayName: Nec Ismcli User
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_ismcli_user
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "M-Series Storage Ld Set Name For Compute Node."
+          displayName: Nec Ldset
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_ldset
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "M-Series Storage Ld Name Format For Snapshots."
+          displayName: Nec Backup Ldname Format
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_backup_ldname_format
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Filename Of Rsa Private Key For M-Series Storage Ismcli."
+          displayName: Nec Ismcli Privkey
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_ismcli_privkey
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Port Number Of Ssh Pool."
+          displayName: Nec Ssh Pool Port Number
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_ssh_pool_port_number
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Fip Address Of M-Series Storage Ismcli."
+          displayName: Nec Ismcli Fip
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_ismcli_fip
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Use Legacy Ismcli Command."
+          displayName: Nec Queryconfig View
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_queryconfig_view
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Maximum Number Of Managing Sessions."
+          displayName: Nec Backend Max Ld Count
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_backend_max_ld_count
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Timeout Value Of Unpairthread."
+          displayName: Nec Unpairthread Timeout
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_unpairthread_timeout
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Configure Access Control Automatically."
+          displayName: Nec Auto Accesscontrol
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_auto_accesscontrol
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Use Legacy Ismcli Command With Optimization."
+          displayName: Nec Ismview Alloptimize
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_ismview_alloptimize
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Output Path Of Ismview File."
+          displayName: Nec Ismview Dir
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_ismview_dir
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Password For M-Series Storage Ismcli."
+          displayName: Nec Ismcli Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_ismcli_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Diskarray Name Of M-Series Storage."
+          displayName: Nec Diskarray Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_diskarray_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Return Actual Free Capacity."
+          displayName: Nec Actual Free Capacity
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_actual_free_capacity
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "M-Series Storage Backup Pool Number To Be Used. [ie: v1,v2]"
+          displayName: Nec Backup Pools
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_backup_pools__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "M-Series Storage Pool Numbers List To Be Used. [ie: v1,v2]"
+          displayName: Nec Pools
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nec_pools__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MStorageISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MStorageISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Volume Configuration File Storage Directory"
+          displayName: Volumes Dir
+          path: config.envVars.X_CSI_BACKEND_CONFIG.volumes_dir
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Path To The Client Certificate For Verification, If The Driver Supports It."
+          displayName: Driver Client Cert
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver_client_cert
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Chap User Name."
+          displayName: Chap Username
+          path: config.envVars.X_CSI_BACKEND_CONFIG.chap_username
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Maximum Number Of Times To Rescan Targets To Find Volume"
+          displayName: Num Volume Device Scan Tries
+          path: config.envVars.X_CSI_BACKEND_CONFIG.num_volume_device_scan_tries
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Prefix For Iscsi Volumes"
+          displayName: Target Prefix
+          path: config.envVars.X_CSI_BACKEND_CONFIG.target_prefix
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Backend Name For A Given Driver Implementation"
+          displayName: Volume Backend Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.volume_backend_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Method Used To Wipe Old Volumes"
+          displayName: Volume Clear
+          path: config.envVars.X_CSI_BACKEND_CONFIG.volume_clear
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:none'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:zero'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Chiscsi (Cxt) Global Defaults Configuration File"
+          displayName: Chiscsi Conf
+          path: config.envVars.X_CSI_BACKEND_CONFIG.chiscsi_conf
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "String Representation For An Equation That Will Be Used To Filter Hosts. Only Used When The Driver Filter Is Set To Be Used By The Cinder Scheduler."
+          displayName: Filter Function
+          path: config.envVars.X_CSI_BACKEND_CONFIG.filter_function
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Namespace For Driver Private Data Values To Be Saved In."
+          displayName: Driver Data Namespace
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver_data_namespace
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Sets The Behavior Of The Iscsi Target To Either Perform Write-Back(On) Or Write-Through(Off). This Parameter Is Valid If Target_Helper Is Set To Tgtadm."
+          displayName: Iscsi Write Cache
+          path: config.envVars.X_CSI_BACKEND_CONFIG.iscsi_write_cache
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:on'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:off'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Flag To Pass To Ionice To Alter The I/O Priority Of The Process Used To Zero A Volume After Deletion, For Example '-C3' For Idle Only Priority."
+          displayName: Volume Clear Ionice
+          path: config.envVars.X_CSI_BACKEND_CONFIG.volume_clear_ionice
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Ip Address That The Iscsi Daemon Is Listening On"
+          displayName: Target Ip Address
+          path: config.envVars.X_CSI_BACKEND_CONFIG.target_ip_address
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Sets The Behavior Of The Iscsi Target To Either Perform Blockio Or Fileio Optionally, Auto Can Be Set And Cinder Will Autodetect Type Of Backing Device"
+          displayName: Iscsi Iotype
+          path: config.envVars.X_CSI_BACKEND_CONFIG.iscsi_iotype
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:blockio'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:fileio'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:auto'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Iet Configuration File"
+          displayName: Iet Conf
+          path: config.envVars.X_CSI_BACKEND_CONFIG.iet_conf
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "List Of Options That Control Which Trace Info Is Written To The Debug Log Level To Assist Developers. Valid Values Are Method And Api. [ie: v1,v2]"
+          displayName: Trace Flags
+          path: config.envVars.X_CSI_BACKEND_CONFIG.trace_flags__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The List Of Secondary Ip Addresses Of The Iscsi Daemon [ie: v1,v2]"
+          displayName: Iscsi Secondary Ip Addresses
+          path: config.envVars.X_CSI_BACKEND_CONFIG.iscsi_secondary_ip_addresses__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Default Block Size Used When Copying/Clearing Volumes"
+          displayName: Volume Dd Blocksize
+          path: config.envVars.X_CSI_BACKEND_CONFIG.volume_dd_blocksize
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Protocol For Transferring Data Between Host And Storage Back-End."
+          displayName: Storage Protocol
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storage_protocol
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:iscsi'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:fc'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "String Representation For An Equation That Will Be Used To Determine The Goodness Of A Host. Only Used When Using The Goodness Weigher Is Set To Be Used By The Cinder Scheduler."
+          displayName: Goodness Function
+          path: config.envVars.X_CSI_BACKEND_CONFIG.goodness_function
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Number Of Times To Attempt To Run Flakey Shell Commands"
+          displayName: Num Shell Tries
+          path: config.envVars.X_CSI_BACKEND_CONFIG.num_shell_tries
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "If Set To True The Http Client Will Validate The Ssl Certificate Of The Backend Endpoint."
+          displayName: Driver Ssl Cert Verify
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver_ssl_cert_verify
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Determines The Target Protocol For New Volumes, Created With Tgtadm, Lioadm And Nvmet Target Helpers. In Order To Enable Rdma, This Parameter Should Be Set With The Value 'Iser'. The Supported Iscsi Protocol Values Are 'Iscsi' And 'Iser', In Case Of Nvmet Target Set To 'Nvmet_Rdma'."
+          displayName: Target Protocol
+          path: config.envVars.X_CSI_BACKEND_CONFIG.target_protocol
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:iscsi'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:iser'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:nvmet_rdma'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Password For Specified Chap Account Name."
+          displayName: Chap Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.chap_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Target User-Land Tool To Use. Tgtadm Is Default, Use Lioadm For Lio Iscsi Support, Scstadmin For Scst Target Support, Ietadm For Iscsi Enterprise Target, Iscsictl For Chelsio Iscsi Target, Nvmet For Nvmeof Support, Spdk-Nvmeof For Spdk Nvme-Of, Or Fake For Testing."
+          displayName: Target Helper
+          path: config.envVars.X_CSI_BACKEND_CONFIG.target_helper
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:tgtadm'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:lioadm'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:scstadmin'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:iscsictl'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:ietadm'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:nvmet'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:spdk-nvmeof'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:fake'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Port That The Iscsi Daemon Is Listening On (min=0, max=65535)"
+          displayName: Target Port
+          path: config.envVars.X_CSI_BACKEND_CONFIG.target_port
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Report To Clients Of Cinder That The Backend Supports Discard (Aka. Trim/Unmap). This Will Not Actually Change The Behavior Of The Backend Or The Client Directly, It Will Only Notify That It Can Be Used."
+          displayName: Report Discard Supported
+          path: config.envVars.X_CSI_BACKEND_CONFIG.report_discard_supported
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Upper Limit Of Bandwidth Of Volume Copy. 0 => Unlimited"
+          displayName: Volume Copy Bps Limit
+          path: config.envVars.X_CSI_BACKEND_CONFIG.volume_copy_bps_limit
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Option To Enable/Disable Chap Authentication For Targets."
+          displayName: Use Chap Auth
+          path: config.envVars.X_CSI_BACKEND_CONFIG.use_chap_auth
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Path To The Client Certificate Key For Verification, If The Driver Supports It."
+          displayName: Driver Client Cert Key
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver_client_cert_key
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Availability Zone For This Volume Backend. If Not Set, The Storage_Availability_Zone Option Value Is Used As The Default For All Backends."
+          displayName: Backend Availability Zone
+          path: config.envVars.X_CSI_BACKEND_CONFIG.backend_availability_zone
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Set This To True When You Want To Allow An Unsupported Driver To Start.  Drivers That Haven'T Maintained A Working Ci System And Testing Are Marked As Unsupported Until Ci Is Working Again.  This Also Marks A Driver As Deprecated And May Be Removed In The Next Release."
+          displayName: Enable Unsupported Driver
+          path: config.envVars.X_CSI_BACKEND_CONFIG.enable_unsupported_driver
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Can Be Used To Specify A Non Default Path To A Ca_Bundle File Or Directory With Certificates Of Trusted Cas, Which Will Be Used To Validate The Backend"
+          displayName: Driver Ssl Cert Path
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver_ssl_cert_path
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Size In Mib To Wipe At Start Of Old Volumes. 1024 Mib At Max. 0 => All (max=1024)"
+          displayName: Volume Clear Size
+          path: config.envVars.X_CSI_BACKEND_CONFIG.volume_clear_size
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Sets The Target-Specific Flags For The Iscsi Target. Only Used For Tgtadm To Specify Backing Device Flags Using Bsoflags Option. The Specified String Is Passed As Is To The Underlying Tool."
+          displayName: Iscsi Target Flags
+          path: config.envVars.X_CSI_BACKEND_CONFIG.iscsi_target_flags
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Blkio Cgroup Name To Be Used To Limit Bandwidth Of Volume Copy"
+          displayName: Volume Copy Blkio Cgroup Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.volume_copy_blkio_cgroup_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Tell Driver To Use Ssl For Connection To Backend Storage If The Driver Supports It."
+          displayName: Driver Use Ssl
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver_use_ssl
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Volume Configuration File Storage Directory"
+          displayName: Volumes Dir
+          path: config.envVars.X_CSI_BACKEND_CONFIG.volumes_dir
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Path To The Client Certificate For Verification, If The Driver Supports It."
+          displayName: Driver Client Cert
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver_client_cert
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Chap User Name."
+          displayName: Chap Username
+          path: config.envVars.X_CSI_BACKEND_CONFIG.chap_username
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Maximum Number Of Times To Rescan Targets To Find Volume"
+          displayName: Num Volume Device Scan Tries
+          path: config.envVars.X_CSI_BACKEND_CONFIG.num_volume_device_scan_tries
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Prefix For Iscsi Volumes"
+          displayName: Target Prefix
+          path: config.envVars.X_CSI_BACKEND_CONFIG.target_prefix
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Backend Name For A Given Driver Implementation"
+          displayName: Volume Backend Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.volume_backend_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Method Used To Wipe Old Volumes"
+          displayName: Volume Clear
+          path: config.envVars.X_CSI_BACKEND_CONFIG.volume_clear
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:none'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:zero'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Chiscsi (Cxt) Global Defaults Configuration File"
+          displayName: Chiscsi Conf
+          path: config.envVars.X_CSI_BACKEND_CONFIG.chiscsi_conf
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "String Representation For An Equation That Will Be Used To Filter Hosts. Only Used When The Driver Filter Is Set To Be Used By The Cinder Scheduler."
+          displayName: Filter Function
+          path: config.envVars.X_CSI_BACKEND_CONFIG.filter_function
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Namespace For Driver Private Data Values To Be Saved In."
+          displayName: Driver Data Namespace
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver_data_namespace
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Sets The Behavior Of The Iscsi Target To Either Perform Write-Back(On) Or Write-Through(Off). This Parameter Is Valid If Target_Helper Is Set To Tgtadm."
+          displayName: Iscsi Write Cache
+          path: config.envVars.X_CSI_BACKEND_CONFIG.iscsi_write_cache
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:on'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:off'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Flag To Pass To Ionice To Alter The I/O Priority Of The Process Used To Zero A Volume After Deletion, For Example '-C3' For Idle Only Priority."
+          displayName: Volume Clear Ionice
+          path: config.envVars.X_CSI_BACKEND_CONFIG.volume_clear_ionice
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Ip Address That The Iscsi Daemon Is Listening On"
+          displayName: Target Ip Address
+          path: config.envVars.X_CSI_BACKEND_CONFIG.target_ip_address
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Sets The Behavior Of The Iscsi Target To Either Perform Blockio Or Fileio Optionally, Auto Can Be Set And Cinder Will Autodetect Type Of Backing Device"
+          displayName: Iscsi Iotype
+          path: config.envVars.X_CSI_BACKEND_CONFIG.iscsi_iotype
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:blockio'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:fileio'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:auto'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Iet Configuration File"
+          displayName: Iet Conf
+          path: config.envVars.X_CSI_BACKEND_CONFIG.iet_conf
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "List Of Options That Control Which Trace Info Is Written To The Debug Log Level To Assist Developers. Valid Values Are Method And Api. [ie: v1,v2]"
+          displayName: Trace Flags
+          path: config.envVars.X_CSI_BACKEND_CONFIG.trace_flags__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The List Of Secondary Ip Addresses Of The Iscsi Daemon [ie: v1,v2]"
+          displayName: Iscsi Secondary Ip Addresses
+          path: config.envVars.X_CSI_BACKEND_CONFIG.iscsi_secondary_ip_addresses__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Default Block Size Used When Copying/Clearing Volumes"
+          displayName: Volume Dd Blocksize
+          path: config.envVars.X_CSI_BACKEND_CONFIG.volume_dd_blocksize
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Protocol For Transferring Data Between Host And Storage Back-End."
+          displayName: Storage Protocol
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storage_protocol
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:iscsi'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:fc'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "String Representation For An Equation That Will Be Used To Determine The Goodness Of A Host. Only Used When Using The Goodness Weigher Is Set To Be Used By The Cinder Scheduler."
+          displayName: Goodness Function
+          path: config.envVars.X_CSI_BACKEND_CONFIG.goodness_function
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Number Of Times To Attempt To Run Flakey Shell Commands"
+          displayName: Num Shell Tries
+          path: config.envVars.X_CSI_BACKEND_CONFIG.num_shell_tries
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "If Set To True The Http Client Will Validate The Ssl Certificate Of The Backend Endpoint."
+          displayName: Driver Ssl Cert Verify
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver_ssl_cert_verify
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Determines The Target Protocol For New Volumes, Created With Tgtadm, Lioadm And Nvmet Target Helpers. In Order To Enable Rdma, This Parameter Should Be Set With The Value 'Iser'. The Supported Iscsi Protocol Values Are 'Iscsi' And 'Iser', In Case Of Nvmet Target Set To 'Nvmet_Rdma'."
+          displayName: Target Protocol
+          path: config.envVars.X_CSI_BACKEND_CONFIG.target_protocol
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:iscsi'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:iser'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:nvmet_rdma'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Password For Specified Chap Account Name."
+          displayName: Chap Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.chap_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Target User-Land Tool To Use. Tgtadm Is Default, Use Lioadm For Lio Iscsi Support, Scstadmin For Scst Target Support, Ietadm For Iscsi Enterprise Target, Iscsictl For Chelsio Iscsi Target, Nvmet For Nvmeof Support, Spdk-Nvmeof For Spdk Nvme-Of, Or Fake For Testing."
+          displayName: Target Helper
+          path: config.envVars.X_CSI_BACKEND_CONFIG.target_helper
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:tgtadm'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:lioadm'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:scstadmin'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:iscsictl'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:ietadm'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:nvmet'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:spdk-nvmeof'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:fake'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Port That The Iscsi Daemon Is Listening On (min=0, max=65535)"
+          displayName: Target Port
+          path: config.envVars.X_CSI_BACKEND_CONFIG.target_port
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Report To Clients Of Cinder That The Backend Supports Discard (Aka. Trim/Unmap). This Will Not Actually Change The Behavior Of The Backend Or The Client Directly, It Will Only Notify That It Can Be Used."
+          displayName: Report Discard Supported
+          path: config.envVars.X_CSI_BACKEND_CONFIG.report_discard_supported
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Upper Limit Of Bandwidth Of Volume Copy. 0 => Unlimited"
+          displayName: Volume Copy Bps Limit
+          path: config.envVars.X_CSI_BACKEND_CONFIG.volume_copy_bps_limit
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Option To Enable/Disable Chap Authentication For Targets."
+          displayName: Use Chap Auth
+          path: config.envVars.X_CSI_BACKEND_CONFIG.use_chap_auth
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Path To The Client Certificate Key For Verification, If The Driver Supports It."
+          displayName: Driver Client Cert Key
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver_client_cert_key
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Availability Zone For This Volume Backend. If Not Set, The Storage_Availability_Zone Option Value Is Used As The Default For All Backends."
+          displayName: Backend Availability Zone
+          path: config.envVars.X_CSI_BACKEND_CONFIG.backend_availability_zone
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Set This To True When You Want To Allow An Unsupported Driver To Start.  Drivers That Haven'T Maintained A Working Ci System And Testing Are Marked As Unsupported Until Ci Is Working Again.  This Also Marks A Driver As Deprecated And May Be Removed In The Next Release."
+          displayName: Enable Unsupported Driver
+          path: config.envVars.X_CSI_BACKEND_CONFIG.enable_unsupported_driver
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Can Be Used To Specify A Non Default Path To A Ca_Bundle File Or Directory With Certificates Of Trusted Cas, Which Will Be Used To Validate The Backend"
+          displayName: Driver Ssl Cert Path
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver_ssl_cert_path
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Size In Mib To Wipe At Start Of Old Volumes. 1024 Mib At Max. 0 => All (max=1024)"
+          displayName: Volume Clear Size
+          path: config.envVars.X_CSI_BACKEND_CONFIG.volume_clear_size
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Sets The Target-Specific Flags For The Iscsi Target. Only Used For Tgtadm To Specify Backing Device Flags Using Bsoflags Option. The Specified String Is Passed As Is To The Underlying Tool."
+          displayName: Iscsi Target Flags
+          path: config.envVars.X_CSI_BACKEND_CONFIG.iscsi_target_flags
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Blkio Cgroup Name To Be Used To Limit Bandwidth Of Volume Copy"
+          displayName: Volume Copy Blkio Cgroup Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.volume_copy_blkio_cgroup_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Tell Driver To Use Ssl For Connection To Backend Storage If The Driver Supports It."
+          displayName: Driver Use Ssl
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver_use_ssl
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:MacroSANISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:MacroSANISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "This Option Specifies The Virtual Storage Server (Vserver) Name On The Storage Cluster On Which Provisioning Of Block Storage Volumes Should Occur."
+          displayName: Netapp Vserver
+          path: config.envVars.X_CSI_BACKEND_CONFIG.netapp_vserver
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NetAppCmodeFibreChannelOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NetAppCmodeFibreChannel'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "This Option Specifies The Virtual Storage Server (Vserver) Name On The Storage Cluster On Which Provisioning Of Block Storage Volumes Should Occur."
+          displayName: Netapp Vserver
+          path: config.envVars.X_CSI_BACKEND_CONFIG.netapp_vserver
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NetAppCmodeISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NetAppCmodeISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Template String To Generate Origin Name Of Clone"
+          displayName: Nexenta Origin Snapshot Template
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nexenta_origin_snapshot_template
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NexentaISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "A Folder Where Cinder Created Datasets Will Reside."
+          displayName: Nexenta Folder
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nexenta_folder
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NexentaISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Group Of Hosts Which Are Allowed To Access Volumes"
+          displayName: Nexenta Iscsi Target Host Group
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nexenta_iscsi_target_host_group
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NexentaISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Amount Of Luns Per Iscsi Target"
+          displayName: Nexenta Luns Per Target
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nexenta_luns_per_target
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NexentaISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Deduplication Value For New Zfs Folders."
+          displayName: Nexenta Dataset Dedup
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nexenta_dataset_dedup
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NexentaISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:on'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:off'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:sha256'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:verify'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:sha256'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:verify'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies The Backoff Factor To Apply Between Connection Attempts To Nexentastor Management Rest Api Server"
+          displayName: Nexenta Rest Backoff Factor
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nexenta_rest_backoff_factor
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NexentaISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Volume Group For Nexentastor5 Iscsi"
+          displayName: Nexenta Volume Group
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nexenta_volume_group
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NexentaISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Comma Separated List Of Portals For Nexentastor5, In Format Of Ip1:Port1,Ip2:Port2. Port Is Optional, Default=3260. Example: 10.10.10.1:3267,10.10.1.2"
+          displayName: Nexenta Iscsi Target Portals
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nexenta_iscsi_target_portals
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NexentaISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Prefix For Iscsi Host Groups On Nexentastor"
+          displayName: Nexenta Host Group Prefix
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nexenta_host_group_prefix
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NexentaISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Human-Readable Description For The Folder."
+          displayName: Nexenta Dataset Description
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nexenta_dataset_description
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NexentaISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies The Number Of Times To Repeat Nexentastor Management Rest Api Call In Case Of Connection Errors And Nexentastor Appliance Ebusy Or Enoent Errors"
+          displayName: Nexenta Rest Retry Count
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nexenta_rest_retry_count
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NexentaISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Ip Address Of Nexentastor Appliance"
+          displayName: Nexenta Host
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nexenta_host
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NexentaISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Use Http Secure Protocol For Nexentastor Management Rest Api Connections"
+          displayName: Nexenta Use Https
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nexenta_use_https
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NexentaISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Nexentastor Pool Name That Holds All Volumes"
+          displayName: Nexenta Volume
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nexenta_volume
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NexentaISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Nexentastor Target Portal Groups"
+          displayName: Nexenta Iscsi Target Portal Groups
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nexenta_iscsi_target_portal_groups
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NexentaISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Compression Value For New Zfs Folders."
+          displayName: Nexenta Dataset Compression
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nexenta_dataset_compression
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NexentaISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:on'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:off'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:gzip'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:gzip-1'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:gzip-2'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:gzip-3'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:gzip-4'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:gzip-5'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:gzip-6'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:gzip-7'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:gzip-8'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:gzip-9'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:lzjb'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:zle'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:lz4'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies The Time Limit (In Seconds), Within Which Nexentastor Management Rest Api Server Must Send A Response"
+          displayName: Nexenta Rest Read Timeout
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nexenta_rest_read_timeout
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NexentaISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies The Time Limit (In Seconds), Within Which The Connection To Nexentastor Management Rest Api Server Must Be Established"
+          displayName: Nexenta Rest Connect Timeout
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nexenta_rest_connect_timeout
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NexentaISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Prefix For Iscsi Target Groups On Nexentastor"
+          displayName: Nexenta Target Group Prefix
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nexenta_target_group_prefix
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NexentaISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Enables Or Disables The Creation Of Sparse Datasets"
+          displayName: Nexenta Sparse
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nexenta_sparse
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NexentaISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Iqn Prefix For Nexentastor Iscsi Targets"
+          displayName: Nexenta Target Prefix
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nexenta_target_prefix
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NexentaISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Postponed Write To Backing Store Or Not"
+          displayName: Nexenta Lu Writebackcache Disabled
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nexenta_lu_writebackcache_disabled
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NexentaISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Block Size For Datasets"
+          displayName: Nexenta Ns5 Blocksize
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nexenta_ns5_blocksize
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NexentaISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Nexenta Appliance Iscsi Target Portal Port"
+          displayName: Nexenta Iscsi Target Portal Port
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nexenta_iscsi_target_portal_port
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NexentaISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Use Http Or Https For Nexentastor Management Rest Api Connection (Default Auto)"
+          displayName: Nexenta Rest Protocol
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nexenta_rest_protocol
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NexentaISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:http'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:https'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:auto'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Template String To Generate Group Snapshot Name"
+          displayName: Nexenta Group Snapshot Template
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nexenta_group_snapshot_template
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NexentaISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Block Size For Datasets"
+          displayName: Nexenta Blocksize
+          path: config.envVars.X_CSI_BACKEND_CONFIG.nexenta_blocksize
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:NexentaISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:NexentaISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Pool In Which Volumes Will Be Created. Defaults To 'Default'."
+          displayName: Eqlx Pool
+          path: config.envVars.X_CSI_BACKEND_CONFIG.eqlx_pool
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PSSeriesISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PSSeriesISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Group Name To Use For Creating Volumes. Defaults To 'Group-0'."
+          displayName: Eqlx Group Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.eqlx_group_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PSSeriesISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PSSeriesISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Maximum Retry Count For Reconnection. Default Is 5. (min=0)"
+          displayName: Eqlx Cli Max Retries
+          path: config.envVars.X_CSI_BACKEND_CONFIG.eqlx_cli_max_retries
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PSSeriesISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PSSeriesISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Serial Number Of The Array To Connect To."
+          displayName: Powermax Array
+          path: config.envVars.X_CSI_BACKEND_CONFIG.powermax_array
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "A Backoff Factor To Apply Between Attempts After The Second Try (Most Errors Are Resolved Immediately By A Second Try Without A Delay). Retries Will Sleep For: {Backoff Factor} * (2 ^ ({Number Of Total Retries} - 1)) Seconds."
+          displayName: U4P Failover Backoff Factor
+          path: config.envVars.X_CSI_BACKEND_CONFIG.u4p_failover_backoff_factor
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Service Level To Use For Provisioning Storage. Setting This As An Extra Spec In Pool_Name Is Preferable."
+          displayName: Powermax Service Level
+          path: config.envVars.X_CSI_BACKEND_CONFIG.powermax_service_level
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Ip Address Of San Controller"
+          displayName: San Ip
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_ip
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "List Of Port Groups Containing Frontend Ports Configured Prior For Server Connection. [ie: v1,v2]"
+          displayName: Powermax Port Groups
+          path: config.envVars.X_CSI_BACKEND_CONFIG.powermax_port_groups__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "If The Driver Should Automatically Failback To The Primary Instance Of Unisphere When A Successful Connection Is Re-Established."
+          displayName: U4P Failover Autofailback
+          path: config.envVars.X_CSI_BACKEND_CONFIG.u4p_failover_autofailback
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Password For San Controller"
+          displayName: San Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Maximum Number Of Retries Each Connection Should Attempt. Note, This Applies Only To Failed Dns Lookups, Socket Connections And Connection Timeouts, Never To Requests Where Data Has Made It To The Server."
+          displayName: U4P Failover Retries
+          path: config.envVars.X_CSI_BACKEND_CONFIG.u4p_failover_retries
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "If Set To True The Http Client Will Validate The Ssl Certificate Of The Backend Endpoint."
+          displayName: Driver Ssl Cert Verify
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver_ssl_cert_verify
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Username For San Controller"
+          displayName: San Login
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_login
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Use This Value To Specify The Maximum Number Of Unlinks For The Temporary Snapshots Before A Clone Operation."
+          displayName: Powermax Snapvx Unlink Limit
+          path: config.envVars.X_CSI_BACKEND_CONFIG.powermax_snapvx_unlink_limit
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Use This Value To Enable The Initiator_Check."
+          displayName: Initiator Check
+          path: config.envVars.X_CSI_BACKEND_CONFIG.initiator_check
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Use This Value To Specify Number Of Retries."
+          displayName: Retries
+          path: config.envVars.X_CSI_BACKEND_CONFIG.retries
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Use This Value To Specify Length Of The Interval In Seconds."
+          displayName: Interval
+          path: config.envVars.X_CSI_BACKEND_CONFIG.interval
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Dictionary Of Unisphere Failover Target Info. [ie: k1:v1,k2:v2]"
+          displayName: U4P Failover Target
+          path: config.envVars.X_CSI_BACKEND_CONFIG.u4p_failover_target__transform_csv_kvs
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Workload, Setting This As An Extra Spec In Pool_Name Is Preferable."
+          displayName: Vmax Workload
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmax_workload
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Storage Resource Pool On Array To Use For Provisioning."
+          displayName: Powermax Srp
+          path: config.envVars.X_CSI_BACKEND_CONFIG.powermax_srp
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "How Long To Wait For The Server To Send Data Before Giving Up."
+          displayName: U4P Failover Timeout
+          path: config.envVars.X_CSI_BACKEND_CONFIG.u4p_failover_timeout
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Chap User Name."
+          displayName: Chap Username
+          path: config.envVars.X_CSI_BACKEND_CONFIG.chap_username
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Serial Number Of The Array To Connect To."
+          displayName: Powermax Array
+          path: config.envVars.X_CSI_BACKEND_CONFIG.powermax_array
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "A Backoff Factor To Apply Between Attempts After The Second Try (Most Errors Are Resolved Immediately By A Second Try Without A Delay). Retries Will Sleep For: {Backoff Factor} * (2 ^ ({Number Of Total Retries} - 1)) Seconds."
+          displayName: U4P Failover Backoff Factor
+          path: config.envVars.X_CSI_BACKEND_CONFIG.u4p_failover_backoff_factor
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Service Level To Use For Provisioning Storage. Setting This As An Extra Spec In Pool_Name Is Preferable."
+          displayName: Powermax Service Level
+          path: config.envVars.X_CSI_BACKEND_CONFIG.powermax_service_level
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Ip Address Of San Controller"
+          displayName: San Ip
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_ip
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "List Of Port Groups Containing Frontend Ports Configured Prior For Server Connection. [ie: v1,v2]"
+          displayName: Powermax Port Groups
+          path: config.envVars.X_CSI_BACKEND_CONFIG.powermax_port_groups__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Password For Specified Chap Account Name."
+          displayName: Chap Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.chap_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "If The Driver Should Automatically Failback To The Primary Instance Of Unisphere When A Successful Connection Is Re-Established."
+          displayName: U4P Failover Autofailback
+          path: config.envVars.X_CSI_BACKEND_CONFIG.u4p_failover_autofailback
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Password For San Controller"
+          displayName: San Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Maximum Number Of Retries Each Connection Should Attempt. Note, This Applies Only To Failed Dns Lookups, Socket Connections And Connection Timeouts, Never To Requests Where Data Has Made It To The Server."
+          displayName: U4P Failover Retries
+          path: config.envVars.X_CSI_BACKEND_CONFIG.u4p_failover_retries
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "If Set To True The Http Client Will Validate The Ssl Certificate Of The Backend Endpoint."
+          displayName: Driver Ssl Cert Verify
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver_ssl_cert_verify
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Username For San Controller"
+          displayName: San Login
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_login
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Use This Value To Specify The Maximum Number Of Unlinks For The Temporary Snapshots Before A Clone Operation."
+          displayName: Powermax Snapvx Unlink Limit
+          path: config.envVars.X_CSI_BACKEND_CONFIG.powermax_snapvx_unlink_limit
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Use This Value To Enable The Initiator_Check."
+          displayName: Initiator Check
+          path: config.envVars.X_CSI_BACKEND_CONFIG.initiator_check
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Option To Enable/Disable Chap Authentication For Targets."
+          displayName: Use Chap Auth
+          path: config.envVars.X_CSI_BACKEND_CONFIG.use_chap_auth
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Use This Value To Specify Number Of Retries."
+          displayName: Retries
+          path: config.envVars.X_CSI_BACKEND_CONFIG.retries
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Use This Value To Specify Length Of The Interval In Seconds."
+          displayName: Interval
+          path: config.envVars.X_CSI_BACKEND_CONFIG.interval
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Dictionary Of Unisphere Failover Target Info. [ie: k1:v1,k2:v2]"
+          displayName: U4P Failover Target
+          path: config.envVars.X_CSI_BACKEND_CONFIG.u4p_failover_target__transform_csv_kvs
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Workload, Setting This As An Extra Spec In Pool_Name Is Preferable."
+          displayName: Vmax Workload
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmax_workload
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Storage Resource Pool On Array To Use For Provisioning."
+          displayName: Powermax Srp
+          path: config.envVars.X_CSI_BACKEND_CONFIG.powermax_srp
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "How Long To Wait For The Server To Send Data Before Giving Up."
+          displayName: U4P Failover Timeout
+          path: config.envVars.X_CSI_BACKEND_CONFIG.u4p_failover_timeout
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PowerMaxISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PowerMaxISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Snapshot Replication Interval In Seconds."
+          displayName: Pure Replica Interval Default
+          path: config.envVars.X_CSI_BACKEND_CONFIG.pure_replica_interval_default
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Retain How Many Snapshots For Each Day."
+          displayName: Pure Replica Retention Long Term Per Day Default
+          path: config.envVars.X_CSI_BACKEND_CONFIG.pure_replica_retention_long_term_per_day_default
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Pure Pod Name To Use For Sync Replication (Will Be Created If It Does Not Exist)."
+          displayName: Pure Replication Pod Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.pure_replication_pod_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Retain Snapshots Per Day On Target For This Time (In Days.)"
+          displayName: Pure Replica Retention Long Term Default
+          path: config.envVars.X_CSI_BACKEND_CONFIG.pure_replica_retention_long_term_default
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Retain All Snapshots On Target For This Time (In Seconds.)"
+          displayName: Pure Replica Retention Short Term Default
+          path: config.envVars.X_CSI_BACKEND_CONFIG.pure_replica_retention_short_term_default
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "If Set To True The Http Client Will Validate The Ssl Certificate Of The Backend Endpoint."
+          displayName: Driver Ssl Cert Verify
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver_ssl_cert_verify
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Rest Api Authorization Token."
+          displayName: Pure Api Token
+          path: config.envVars.X_CSI_BACKEND_CONFIG.pure_api_token
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Automatically Determine An Oversubscription Ratio Based On The Current Total Data Reduction Values. If Used This Calculated Value Will Override The Max_Over_Subscription_Ratio Config Option."
+          displayName: Pure Automatic Max Oversubscription Ratio
+          path: config.envVars.X_CSI_BACKEND_CONFIG.pure_automatic_max_oversubscription_ratio
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Cidr Of Flasharray Iscsi Targets Hosts Are Allowed To Connect To. Default Will Allow Connection To Any Ip Address."
+          displayName: Pure Iscsi Cidr
+          path: config.envVars.X_CSI_BACKEND_CONFIG.pure_iscsi_cidr
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "When Enabled, All Pure Volumes, Snapshots, And Protection Groups Will Be Eradicated At The Time Of Deletion In Cinder. Data Will Not Be Recoverable After A Delete With This Set To True! When Disabled, Volumes And Snapshots Will Go Into Pending Eradication State And Can Be Recovered."
+          displayName: Pure Eradicate On Delete
+          path: config.envVars.X_CSI_BACKEND_CONFIG.pure_eradicate_on_delete
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Can Be Used To Specify A Non Default Path To A Ca_Bundle File Or Directory With Certificates Of Trusted Cas, Which Will Be Used To Validate The Backend"
+          displayName: Driver Ssl Cert Path
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver_ssl_cert_path
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Option To Enable/Disable Chap Authentication For Targets."
+          displayName: Use Chap Auth
+          path: config.envVars.X_CSI_BACKEND_CONFIG.use_chap_auth
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Pure Protection Group Name To Use For Async Replication (Will Be Created If It Does Not Exist)."
+          displayName: Pure Replication Pg Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.pure_replication_pg_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Ip Address Of San Controller"
+          displayName: San Ip
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_ip
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Determines How The Purity System Tunes The Protocol Used Between The Array And The Initiator."
+          displayName: Pure Host Personality
+          path: config.envVars.X_CSI_BACKEND_CONFIG.pure_host_personality
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:aix'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:esxi'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:hitachi-vsp'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:hpux'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:oracle-vm-server'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:solaris'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:vms'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Snapshot Replication Interval In Seconds."
+          displayName: Pure Replica Interval Default
+          path: config.envVars.X_CSI_BACKEND_CONFIG.pure_replica_interval_default
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Retain How Many Snapshots For Each Day."
+          displayName: Pure Replica Retention Long Term Per Day Default
+          path: config.envVars.X_CSI_BACKEND_CONFIG.pure_replica_retention_long_term_per_day_default
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Pure Pod Name To Use For Sync Replication (Will Be Created If It Does Not Exist)."
+          displayName: Pure Replication Pod Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.pure_replication_pod_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Retain Snapshots Per Day On Target For This Time (In Days.)"
+          displayName: Pure Replica Retention Long Term Default
+          path: config.envVars.X_CSI_BACKEND_CONFIG.pure_replica_retention_long_term_default
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Retain All Snapshots On Target For This Time (In Seconds.)"
+          displayName: Pure Replica Retention Short Term Default
+          path: config.envVars.X_CSI_BACKEND_CONFIG.pure_replica_retention_short_term_default
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "If Set To True The Http Client Will Validate The Ssl Certificate Of The Backend Endpoint."
+          displayName: Driver Ssl Cert Verify
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver_ssl_cert_verify
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Rest Api Authorization Token."
+          displayName: Pure Api Token
+          path: config.envVars.X_CSI_BACKEND_CONFIG.pure_api_token
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Automatically Determine An Oversubscription Ratio Based On The Current Total Data Reduction Values. If Used This Calculated Value Will Override The Max_Over_Subscription_Ratio Config Option."
+          displayName: Pure Automatic Max Oversubscription Ratio
+          path: config.envVars.X_CSI_BACKEND_CONFIG.pure_automatic_max_oversubscription_ratio
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Cidr Of Flasharray Iscsi Targets Hosts Are Allowed To Connect To. Default Will Allow Connection To Any Ip Address."
+          displayName: Pure Iscsi Cidr
+          path: config.envVars.X_CSI_BACKEND_CONFIG.pure_iscsi_cidr
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "When Enabled, All Pure Volumes, Snapshots, And Protection Groups Will Be Eradicated At The Time Of Deletion In Cinder. Data Will Not Be Recoverable After A Delete With This Set To True! When Disabled, Volumes And Snapshots Will Go Into Pending Eradication State And Can Be Recovered."
+          displayName: Pure Eradicate On Delete
+          path: config.envVars.X_CSI_BACKEND_CONFIG.pure_eradicate_on_delete
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Can Be Used To Specify A Non Default Path To A Ca_Bundle File Or Directory With Certificates Of Trusted Cas, Which Will Be Used To Validate The Backend"
+          displayName: Driver Ssl Cert Path
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver_ssl_cert_path
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Option To Enable/Disable Chap Authentication For Targets."
+          displayName: Use Chap Auth
+          path: config.envVars.X_CSI_BACKEND_CONFIG.use_chap_auth
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Pure Protection Group Name To Use For Async Replication (Will Be Created If It Does Not Exist)."
+          displayName: Pure Replication Pg Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.pure_replication_pg_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Ip Address Of San Controller"
+          displayName: San Ip
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_ip
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Determines How The Purity System Tunes The Protocol Used Between The Array And The Initiator."
+          displayName: Pure Host Personality
+          path: config.envVars.X_CSI_BACKEND_CONFIG.pure_host_personality
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:PureISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:aix'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:esxi'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:hitachi-vsp'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:hpux'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:oracle-vm-server'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:solaris'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:vms'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:PureISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Password For San Controller"
+          displayName: San Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:QnapISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:QnapISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Chap User Name."
+          displayName: Chap Username
+          path: config.envVars.X_CSI_BACKEND_CONFIG.chap_username
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:QnapISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:QnapISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Ip Address That The Iscsi Daemon Is Listening On"
+          displayName: Target Ip Address
+          path: config.envVars.X_CSI_BACKEND_CONFIG.target_ip_address
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:QnapISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:QnapISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Username For San Controller"
+          displayName: San Login
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_login
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:QnapISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:QnapISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "If Set To True The Http Client Will Validate The Ssl Certificate Of The Backend Endpoint."
+          displayName: Driver Ssl Cert Verify
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver_ssl_cert_verify
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:QnapISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:QnapISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Url To Management Qnap Storage. Driver Does Not Support Ipv6 Address In Url."
+          displayName: Qnap Management Url
+          path: config.envVars.X_CSI_BACKEND_CONFIG.qnap_management_url
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:QnapISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:QnapISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Communication Protocol To Access Qnap Storage"
+          displayName: Qnap Storage Protocol
+          path: config.envVars.X_CSI_BACKEND_CONFIG.qnap_storage_protocol
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:QnapISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:QnapISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Password For Specified Chap Account Name."
+          displayName: Chap Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.chap_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:QnapISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:QnapISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Option To Enable/Disable Chap Authentication For Targets."
+          displayName: Use Chap Auth
+          path: config.envVars.X_CSI_BACKEND_CONFIG.use_chap_auth
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:QnapISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:QnapISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Pool Name In The Qnap Storage"
+          displayName: Qnap Poolname
+          path: config.envVars.X_CSI_BACKEND_CONFIG.qnap_poolname
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:QnapISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:QnapISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Quobyte Url To The Quobyte Volume Using E.G. A Dns Srv Record (Preferred) Or A Host List (Alternatively) Like Quobyte://<Dir Host1>, <Dir Host2>/<Volume Name>"
+          displayName: Quobyte Volume Url
+          path: config.envVars.X_CSI_BACKEND_CONFIG.quobyte_volume_url
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:QuobyteOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:Quobyte'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Create New Volumes From The Volume_From_Snapshot_Cache By Creating Overlay Files Instead Of Full Copies. This Speeds Up The Creation Of Volumes From This Cache. This Feature Requires The Options Quobyte_Qcow2_Volumes And Quobyte_Volume_From_Snapshot_Cache To Be Set To True. If One Of These Is Set To False This Option Is Ignored."
+          displayName: Quobyte Overlay Volumes
+          path: config.envVars.X_CSI_BACKEND_CONFIG.quobyte_overlay_volumes
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:QuobyteOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:Quobyte'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Create A Cache Of Volumes From Merged Snapshots To Speed Up Creation Of Multiple Volumes From A Single Snapshot."
+          displayName: Quobyte Volume From Snapshot Cache
+          path: config.envVars.X_CSI_BACKEND_CONFIG.quobyte_volume_from_snapshot_cache
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:QuobyteOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:Quobyte'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Create Volumes As Qcow2 Files Rather Than Raw Files."
+          displayName: Quobyte Qcow2 Volumes
+          path: config.envVars.X_CSI_BACKEND_CONFIG.quobyte_qcow2_volumes
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:QuobyteOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:Quobyte'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Create Volumes As Sparse Files Which Take No Space. If Set To False, Volume Is Created As Regular File."
+          displayName: Quobyte Sparsed Volumes
+          path: config.envVars.X_CSI_BACKEND_CONFIG.quobyte_sparsed_volumes
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:QuobyteOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:Quobyte'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Path To A Quobyte Client Configuration File."
+          displayName: Quobyte Client Cfg
+          path: config.envVars.X_CSI_BACKEND_CONFIG.quobyte_client_cfg
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:QuobyteOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:Quobyte'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Base Dir Containing The Mount Point For The Quobyte Volume."
+          displayName: Quobyte Mount Point Base
+          path: config.envVars.X_CSI_BACKEND_CONFIG.quobyte_mount_point_base
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:QuobyteOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:Quobyte'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Volumes Will Be Chunked Into Objects Of This Size (In Megabytes)."
+          displayName: Rbd Store Chunk Size
+          path: config.envVars.X_CSI_BACKEND_CONFIG.rbd_store_chunk_size
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBDOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:RBD'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Number Of Retries If Connection To Ceph Cluster Failed."
+          displayName: Rados Connection Retries
+          path: config.envVars.X_CSI_BACKEND_CONFIG.rados_connection_retries
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBDOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:RBD'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Name Of Ceph Cluster"
+          displayName: Rbd Cluster Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.rbd_cluster_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBDOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:RBD'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Libvirt Uuid Of The Secret For The Rbd_User Volumes"
+          displayName: Rbd Secret Uuid
+          path: config.envVars.X_CSI_BACKEND_CONFIG.rbd_secret_uuid
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBDOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:RBD'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Path To The Ceph Configuration File"
+          displayName: Rbd Ceph Conf
+          path: config.envVars.X_CSI_BACKEND_CONFIG.rbd_ceph_conf
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBDOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:RBD'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Enable Deferred Deletion. Upon Deletion, Volumes Are Tagged For Deletion But Will Only Be Removed Asynchronously At A Later Time."
+          displayName: Enable Deferred Deletion
+          path: config.envVars.X_CSI_BACKEND_CONFIG.enable_deferred_deletion
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBDOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:RBD'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Set To True For Driver To Report Total Capacity As A Dynamic Value (Used + Current Free) And To False To Report A Static Value (Quota Max Bytes If Defined And Global Size Of Cluster If Not)."
+          displayName: Report Dynamic Total Capacity
+          path: config.envVars.X_CSI_BACKEND_CONFIG.report_dynamic_total_capacity
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBDOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:RBD'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Set To True If The Pool Is Used Exclusively By Cinder. On Exclusive Use Driver Won'T Query Images' Provisioned Size As They Will Match The Value Calculated By The Cinder Core Code For Allocated_Capacity_Gb. This Reduces The Load On The Ceph Cluster As Well As On The Volume Service."
+          displayName: Rbd Exclusive Cinder Pool
+          path: config.envVars.X_CSI_BACKEND_CONFIG.rbd_exclusive_cinder_pool
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBDOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:RBD'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Interval Value (In Seconds) Between Connection Retries To Ceph Cluster."
+          displayName: Rados Connection Interval
+          path: config.envVars.X_CSI_BACKEND_CONFIG.rados_connection_interval
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBDOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:RBD'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Rados Client Name For Accessing Rbd Volumes - Only Set When Using Cephx Authentication"
+          displayName: Rbd User
+          path: config.envVars.X_CSI_BACKEND_CONFIG.rbd_user
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBDOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:RBD'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Timeout Value (In Seconds) Used When Connecting To Ceph Cluster. If Value < 0, No Timeout Is Set And Default Librados Value Is Used."
+          displayName: Rados Connect Timeout
+          path: config.envVars.X_CSI_BACKEND_CONFIG.rados_connect_timeout
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBDOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:RBD'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Rados Pool Where Rbd Volumes Are Stored"
+          displayName: Rbd Pool
+          path: config.envVars.X_CSI_BACKEND_CONFIG.rbd_pool
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBDOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:RBD'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Flatten Volumes Created From Snapshots To Remove Dependency From Volume To Snapshot"
+          displayName: Rbd Flatten Volume From Snapshot
+          path: config.envVars.X_CSI_BACKEND_CONFIG.rbd_flatten_volume_from_snapshot
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBDOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:RBD'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Maximum Number Of Nested Volume Clones That Are Taken Before A Flatten Occurs. Set To 0 To Disable Cloning."
+          displayName: Rbd Max Clone Depth
+          path: config.envVars.X_CSI_BACKEND_CONFIG.rbd_max_clone_depth
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBDOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:RBD'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Time Delay In Seconds Before A Volume Is Eligible For Permanent Removal After Being Tagged For Deferred Deletion."
+          displayName: Deferred Deletion Delay
+          path: config.envVars.X_CSI_BACKEND_CONFIG.deferred_deletion_delay
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBDOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:RBD'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Number Of Seconds Between Runs Of The Periodic Task To Purge Volumes Tagged For Deletion."
+          displayName: Deferred Deletion Purge Interval
+          path: config.envVars.X_CSI_BACKEND_CONFIG.deferred_deletion_purge_interval
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:RBDOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:RBD'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Url Of Podm Service"
+          displayName: Podm Url
+          path: config.envVars.X_CSI_BACKEND_CONFIG.podm_url
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:RSDOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:RSD'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Username Of Podm Service"
+          displayName: Podm Username
+          path: config.envVars.X_CSI_BACKEND_CONFIG.podm_username
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:RSDOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:RSD'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Password Of Podm Service"
+          displayName: Podm Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.podm_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:RSDOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:RSD'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Storage Center System Serial Number"
+          displayName: Dell Sc Ssn
+          path: config.envVars.X_CSI_BACKEND_CONFIG.dell_sc_ssn
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Dell Sc Api Sync Call Default Timeout In Seconds."
+          displayName: Dell Api Sync Rest Timeout
+          path: config.envVars.X_CSI_BACKEND_CONFIG.dell_api_sync_rest_timeout
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Enable Https Sc Certificate Verification"
+          displayName: Dell Sc Verify Cert
+          path: config.envVars.X_CSI_BACKEND_CONFIG.dell_sc_verify_cert
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Dell Sc Api Async Call Default Timeout In Seconds."
+          displayName: Dell Api Async Rest Timeout
+          path: config.envVars.X_CSI_BACKEND_CONFIG.dell_api_async_rest_timeout
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Name Of The Server Folder To Use On The Storage Center"
+          displayName: Dell Sc Server Folder
+          path: config.envVars.X_CSI_BACKEND_CONFIG.dell_sc_server_folder
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Ip Address Of Secondary Dsm Controller"
+          displayName: Secondary San Ip
+          path: config.envVars.X_CSI_BACKEND_CONFIG.secondary_san_ip
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Server Os Type To Use When Creating A New Server On The Storage Center."
+          displayName: Dell Server Os
+          path: config.envVars.X_CSI_BACKEND_CONFIG.dell_server_os
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Dell Api Port (min=0, max=65535)"
+          displayName: Dell Sc Api Port
+          path: config.envVars.X_CSI_BACKEND_CONFIG.dell_sc_api_port
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Secondary Dell Api Port (min=0, max=65535)"
+          displayName: Secondary Sc Api Port
+          path: config.envVars.X_CSI_BACKEND_CONFIG.secondary_sc_api_port
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Secondary Dsm User Name"
+          displayName: Secondary San Login
+          path: config.envVars.X_CSI_BACKEND_CONFIG.secondary_san_login
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Secondary Dsm User Password Name"
+          displayName: Secondary San Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.secondary_san_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Name Of The Volume Folder To Use On The Storage Center"
+          displayName: Dell Sc Volume Folder
+          path: config.envVars.X_CSI_BACKEND_CONFIG.dell_sc_volume_folder
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Comma Separated Fault Domain Ips To Be Excluded From Iscsi Returns. [ie: v1,v2]"
+          displayName: Excluded Domain Ips
+          path: config.envVars.X_CSI_BACKEND_CONFIG.excluded_domain_ips__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Storage Center System Serial Number"
+          displayName: Dell Sc Ssn
+          path: config.envVars.X_CSI_BACKEND_CONFIG.dell_sc_ssn
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Dell Sc Api Sync Call Default Timeout In Seconds."
+          displayName: Dell Api Sync Rest Timeout
+          path: config.envVars.X_CSI_BACKEND_CONFIG.dell_api_sync_rest_timeout
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Enable Https Sc Certificate Verification"
+          displayName: Dell Sc Verify Cert
+          path: config.envVars.X_CSI_BACKEND_CONFIG.dell_sc_verify_cert
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Dell Sc Api Async Call Default Timeout In Seconds."
+          displayName: Dell Api Async Rest Timeout
+          path: config.envVars.X_CSI_BACKEND_CONFIG.dell_api_async_rest_timeout
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Name Of The Server Folder To Use On The Storage Center"
+          displayName: Dell Sc Server Folder
+          path: config.envVars.X_CSI_BACKEND_CONFIG.dell_sc_server_folder
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Ip Address Of Secondary Dsm Controller"
+          displayName: Secondary San Ip
+          path: config.envVars.X_CSI_BACKEND_CONFIG.secondary_san_ip
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Server Os Type To Use When Creating A New Server On The Storage Center."
+          displayName: Dell Server Os
+          path: config.envVars.X_CSI_BACKEND_CONFIG.dell_server_os
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Dell Api Port (min=0, max=65535)"
+          displayName: Dell Sc Api Port
+          path: config.envVars.X_CSI_BACKEND_CONFIG.dell_sc_api_port
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Secondary Dell Api Port (min=0, max=65535)"
+          displayName: Secondary Sc Api Port
+          path: config.envVars.X_CSI_BACKEND_CONFIG.secondary_sc_api_port
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Secondary Dsm User Name"
+          displayName: Secondary San Login
+          path: config.envVars.X_CSI_BACKEND_CONFIG.secondary_san_login
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Secondary Dsm User Password Name"
+          displayName: Secondary San Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.secondary_san_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Name Of The Volume Folder To Use On The Storage Center"
+          displayName: Dell Sc Volume Folder
+          path: config.envVars.X_CSI_BACKEND_CONFIG.dell_sc_volume_folder
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Comma Separated Fault Domain Ips To Be Excluded From Iscsi Returns. [ie: v1,v2]"
+          displayName: Excluded Domain Ips
+          path: config.envVars.X_CSI_BACKEND_CONFIG.excluded_domain_ips__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Ip Address Of Sheep Daemon."
+          displayName: Sheepdog Store Address
+          path: config.envVars.X_CSI_BACKEND_CONFIG.sheepdog_store_address
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SheepdogOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:Sheepdog'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Port Of Sheep Daemon. (min=0, max=65535)"
+          displayName: Sheepdog Store Port
+          path: config.envVars.X_CSI_BACKEND_CONFIG.sheepdog_store_port
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SheepdogOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:Sheepdog'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Overrides Default Cluster Svip With The One Specified. This Is Required Or Deployments That Have Implemented The Use Of Vlans For Iscsi Networks In Their Cloud."
+          displayName: Sf Svip
+          path: config.envVars.X_CSI_BACKEND_CONFIG.sf_svip
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SolidFireOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SolidFire'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Solidfire Api Port. Useful If The Device Api Is Behind A Proxy On A Different Port. (min=0, max=65535)"
+          displayName: Sf Api Port
+          path: config.envVars.X_CSI_BACKEND_CONFIG.sf_api_port
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SolidFireOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SolidFire'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Allow Tenants To Specify Qos On Create"
+          displayName: Sf Allow Tenant Qos
+          path: config.envVars.X_CSI_BACKEND_CONFIG.sf_allow_tenant_qos
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SolidFireOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SolidFire'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Create Solidfire Volumes With This Prefix. Volume Names Are Of The Form <Sf_Volume_Prefix><Cinder-Volume-Id>.  The Default Is To Use A Prefix Of 'Uuid-'."
+          displayName: Sf Volume Prefix
+          path: config.envVars.X_CSI_BACKEND_CONFIG.sf_volume_prefix
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SolidFireOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SolidFire'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Utilize Volume Access Groups On A Per-Tenant Basis."
+          displayName: Sf Enable Vag
+          path: config.envVars.X_CSI_BACKEND_CONFIG.sf_enable_vag
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SolidFireOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SolidFire'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "If Set To True The Http Client Will Validate The Ssl Certificate Of The Backend Endpoint."
+          displayName: Driver Ssl Cert Verify
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver_ssl_cert_verify
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SolidFireOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SolidFire'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Username For San Controller"
+          displayName: San Login
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_login
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SolidFireOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SolidFire'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Create Solidfire Accounts With This Prefix. Any String Can Be Used Here, But The String 'Hostname' Is Special And Will Create A Prefix Using The Cinder Node Hostname (Previous Default Behavior).  The Default Is No Prefix."
+          displayName: Sf Account Prefix
+          path: config.envVars.X_CSI_BACKEND_CONFIG.sf_account_prefix
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SolidFireOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SolidFire'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Password For San Controller"
+          displayName: San Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SolidFireOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SolidFire'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Change How Solidfire Reports Used Space And Provisioning Calculations. If This Parameter Is Set To 'Usedspace', The  Driver Will Report Correct Values As Expected By Cinder Thin Provisioning."
+          displayName: Sf Provisioning Calc
+          path: config.envVars.X_CSI_BACKEND_CONFIG.sf_provisioning_calc
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SolidFireOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:maxProvisionedSpace'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:usedSpace'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SolidFire'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Ip Address Of San Controller"
+          displayName: San Ip
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_ip
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SolidFireOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SolidFire'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Set 512 Byte Emulation On Volume Creation; "
+          displayName: Sf Emulate 512
+          path: config.envVars.X_CSI_BACKEND_CONFIG.sf_emulate_512
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SolidFireOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SolidFire'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Default Storpool Chain Replication Value.  Used When Creating A Volume With No Specified Type If Storpool_Template Is Not Set.  Also Used For Calculating The Apparent Free Space Reported In The Stats."
+          displayName: Storpool Replication
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storpool_replication
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorPoolOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorPool'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Storpool Template For Volumes With No Type."
+          displayName: Storpool Template
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storpool_template
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorPoolOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorPool'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Maximum Number Of Seconds To Wait For Flashcopy To Be Prepared. (min=1, max=600)"
+          displayName: Storwize Svc Flashcopy Timeout
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_flashcopy_timeout
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Storage System Autoexpand Parameter For Volumes (True/False)"
+          displayName: Storwize Svc Vol Autoexpand
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_vol_autoexpand
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies Secondary Management Ip Or Hostname To Be Used If San_Ip Is Invalid Or Becomes Inaccessible."
+          displayName: Storwize San Secondary Ip
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_san_secondary_ip
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies The Storwize Flashcopy Copy Rate To Be Used When Creating A Full Volume Copy. The Default Is Rate Is 50, And The Valid Rates Are 1-150. (min=1, max=150)"
+          displayName: Storwize Svc Flashcopy Rate
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_flashcopy_rate
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Storage System Grain Size Parameter For Volumes (8/32/64/128/256)"
+          displayName: Storwize Svc Vol Grainsize
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_vol_grainsize
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Connect With Multipath (Fc Only; Iscsi Multipath Is Controlled By Nova)"
+          displayName: Storwize Svc Multipath Enabled
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_multipath_enabled
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "If Operating In Stretched Cluster Mode, Specify The Name Of The Pool In Which Mirrored Copies Are Stored.Example: 'Pool2'"
+          displayName: Storwize Svc Stretched Cluster Partner
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_stretched_cluster_partner
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Storage System Compression Option For Volumes"
+          displayName: Storwize Svc Vol Compression
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_vol_compression
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Enable Easy Tier For Volumes"
+          displayName: Storwize Svc Vol Easytier
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_vol_easytier
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Storage System Space-Efficiency Parameter For Volumes (Percentage) (min=-1, max=100)"
+          displayName: Storwize Svc Vol Rsize
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_vol_rsize
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Comma Separated List Of Storage System Storage Pools For Volumes. [ie: v1,v2]"
+          displayName: Storwize Svc Volpool Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_volpool_name__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies The Name Of The Pool In Which Mirrored Copy Is Stored. Example: 'Pool2'"
+          displayName: Storwize Svc Mirror Pool
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_mirror_pool
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The I/O Group In Which To Allocate Volumes. It Can Be A Comma-Separated List In Which Case The Driver Will Select An Io_Group Based On Least Number Of Volumes Associated With The Io_Group."
+          displayName: Storwize Svc Vol Iogrp
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_vol_iogrp
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Storage System Threshold For Volume Capacity Warnings (Percentage) (min=-1, max=100)"
+          displayName: Storwize Svc Vol Warning
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_vol_warning
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "This Defines An Optional Cycle Period That Applies To Global Mirror Relationships With A Cycling Mode Of Multi. A Global Mirror Relationship Using The Multi Cycling_Mode Performs A Complete Cycle At Most Once Each Period. The Default Is 300 Seconds, And The Valid Seconds Are 60-86400. (min=60, max=86400)"
+          displayName: Cycle Period Seconds
+          path: config.envVars.X_CSI_BACKEND_CONFIG.cycle_period_seconds
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies The Site Information For Host. One Wwpn Or Multi Wwpns Used In The Host Can Be Specified. For Example: Storwize_Preferred_Host_Site=Site1:Wwpn1,Site2:Wwpn2&Wwpn3 Or Storwize_Preferred_Host_Site=Site1:Iqn1,Site2:Iqn2 [ie: k1:v1,k2:v2]"
+          displayName: Storwize Preferred Host Site
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_preferred_host_site__transform_csv_kvs
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Allow Tenants To Specify Qos On Create"
+          displayName: Storwize Svc Allow Tenant Qos
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_allow_tenant_qos
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies That The Volume Not Be Formatted During Creation."
+          displayName: Storwize Svc Vol Nofmtdisk
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_vol_nofmtdisk
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies The Name Of The Peer Pool For Hyperswap Volume, The Peer Pool Must Exist On The Other Site."
+          displayName: Storwize Peer Pool
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_peer_pool
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Maximum Number Of Seconds To Wait For Flashcopy To Be Prepared. (min=1, max=600)"
+          displayName: Storwize Svc Flashcopy Timeout
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_flashcopy_timeout
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Storage System Autoexpand Parameter For Volumes (True/False)"
+          displayName: Storwize Svc Vol Autoexpand
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_vol_autoexpand
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies Secondary Management Ip Or Hostname To Be Used If San_Ip Is Invalid Or Becomes Inaccessible."
+          displayName: Storwize San Secondary Ip
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_san_secondary_ip
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies The Storwize Flashcopy Copy Rate To Be Used When Creating A Full Volume Copy. The Default Is Rate Is 50, And The Valid Rates Are 1-150. (min=1, max=150)"
+          displayName: Storwize Svc Flashcopy Rate
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_flashcopy_rate
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Storage System Grain Size Parameter For Volumes (8/32/64/128/256)"
+          displayName: Storwize Svc Vol Grainsize
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_vol_grainsize
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Storage System Threshold For Volume Capacity Warnings (Percentage) (min=-1, max=100)"
+          displayName: Storwize Svc Vol Warning
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_vol_warning
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies That The Volume Not Be Formatted During Creation."
+          displayName: Storwize Svc Vol Nofmtdisk
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_vol_nofmtdisk
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Storage System Compression Option For Volumes"
+          displayName: Storwize Svc Vol Compression
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_vol_compression
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Enable Easy Tier For Volumes"
+          displayName: Storwize Svc Vol Easytier
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_vol_easytier
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Storage System Space-Efficiency Parameter For Volumes (Percentage) (min=-1, max=100)"
+          displayName: Storwize Svc Vol Rsize
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_vol_rsize
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Comma Separated List Of Storage System Storage Pools For Volumes. [ie: v1,v2]"
+          displayName: Storwize Svc Volpool Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_volpool_name__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Configure Chap Authentication For Iscsi Connections (Default: Enabled)"
+          displayName: Storwize Svc Iscsi Chap Enabled
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_iscsi_chap_enabled
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies The Name Of The Pool In Which Mirrored Copy Is Stored. Example: 'Pool2'"
+          displayName: Storwize Svc Mirror Pool
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_mirror_pool
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "If Operating In Stretched Cluster Mode, Specify The Name Of The Pool In Which Mirrored Copies Are Stored.Example: 'Pool2'"
+          displayName: Storwize Svc Stretched Cluster Partner
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_stretched_cluster_partner
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "This Defines An Optional Cycle Period That Applies To Global Mirror Relationships With A Cycling Mode Of Multi. A Global Mirror Relationship Using The Multi Cycling_Mode Performs A Complete Cycle At Most Once Each Period. The Default Is 300 Seconds, And The Valid Seconds Are 60-86400. (min=60, max=86400)"
+          displayName: Cycle Period Seconds
+          path: config.envVars.X_CSI_BACKEND_CONFIG.cycle_period_seconds
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies The Site Information For Host. One Wwpn Or Multi Wwpns Used In The Host Can Be Specified. For Example: Storwize_Preferred_Host_Site=Site1:Wwpn1,Site2:Wwpn2&Wwpn3 Or Storwize_Preferred_Host_Site=Site1:Iqn1,Site2:Iqn2 [ie: k1:v1,k2:v2]"
+          displayName: Storwize Preferred Host Site
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_preferred_host_site__transform_csv_kvs
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Allow Tenants To Specify Qos On Create"
+          displayName: Storwize Svc Allow Tenant Qos
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_allow_tenant_qos
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The I/O Group In Which To Allocate Volumes. It Can Be A Comma-Separated List In Which Case The Driver Will Select An Io_Group Based On Least Number Of Volumes Associated With The Io_Group."
+          displayName: Storwize Svc Vol Iogrp
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_svc_vol_iogrp
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Specifies The Name Of The Peer Pool For Hyperswap Volume, The Peer Pool Must Exist On The Other Site."
+          displayName: Storwize Peer Pool
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storwize_peer_pool
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:StorwizeSVCISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:StorwizeSVCISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Do Certificate Validation Or Not If $Driver_Use_Ssl Is True"
+          displayName: Synology Ssl Verify
+          path: config.envVars.X_CSI_BACKEND_CONFIG.synology_ssl_verify
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SynoISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SynoISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Device Id For Skip One Time Password Check For Logging In Synology Storage If Otp Is Enabled."
+          displayName: Synology Device Id
+          path: config.envVars.X_CSI_BACKEND_CONFIG.synology_device_id
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SynoISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SynoISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Administrator Of Synology Storage."
+          displayName: Synology Username
+          path: config.envVars.X_CSI_BACKEND_CONFIG.synology_username
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SynoISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SynoISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Volume On Synology Storage To Be Used For Creating Lun."
+          displayName: Synology Pool Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.synology_pool_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SynoISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SynoISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Chap User Name."
+          displayName: Chap Username
+          path: config.envVars.X_CSI_BACKEND_CONFIG.chap_username
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SynoISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SynoISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Determines The Target Protocol For New Volumes, Created With Tgtadm, Lioadm And Nvmet Target Helpers. In Order To Enable Rdma, This Parameter Should Be Set With The Value 'Iser'. The Supported Iscsi Protocol Values Are 'Iscsi' And 'Iser', In Case Of Nvmet Target Set To 'Nvmet_Rdma'."
+          displayName: Target Protocol
+          path: config.envVars.X_CSI_BACKEND_CONFIG.target_protocol
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SynoISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:iscsi'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:iser'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:nvmet_rdma'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SynoISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Tell Driver To Use Ssl For Connection To Backend Storage If The Driver Supports It."
+          displayName: Driver Use Ssl
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver_use_ssl
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SynoISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SynoISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Password For Specified Chap Account Name."
+          displayName: Chap Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.chap_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SynoISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SynoISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "One Time Password Of Administrator For Logging In Synology Storage If Otp Is Enabled."
+          displayName: Synology One Time Pass
+          path: config.envVars.X_CSI_BACKEND_CONFIG.synology_one_time_pass
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SynoISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SynoISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Ip Address That The Iscsi Daemon Is Listening On"
+          displayName: Target Ip Address
+          path: config.envVars.X_CSI_BACKEND_CONFIG.target_ip_address
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SynoISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SynoISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Prefix For Iscsi Volumes"
+          displayName: Target Prefix
+          path: config.envVars.X_CSI_BACKEND_CONFIG.target_prefix
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SynoISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SynoISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Port That The Iscsi Daemon Is Listening On (min=0, max=65535)"
+          displayName: Target Port
+          path: config.envVars.X_CSI_BACKEND_CONFIG.target_port
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SynoISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SynoISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The List Of Secondary Ip Addresses Of The Iscsi Daemon [ie: v1,v2]"
+          displayName: Iscsi Secondary Ip Addresses
+          path: config.envVars.X_CSI_BACKEND_CONFIG.iscsi_secondary_ip_addresses__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SynoISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SynoISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Option To Enable/Disable Chap Authentication For Targets."
+          displayName: Use Chap Auth
+          path: config.envVars.X_CSI_BACKEND_CONFIG.use_chap_auth
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SynoISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SynoISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Password Of Administrator For Logging In Synology Storage."
+          displayName: Synology Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.synology_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SynoISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SynoISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Management Port For Synology Storage. (min=0, max=65535)"
+          displayName: Synology Admin Port
+          path: config.envVars.X_CSI_BACKEND_CONFIG.synology_admin_port
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:SynoISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:SynoISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "A Comma-Separated List Of Iscsi Or Fc Ports To Be Used. Each Port Can Be Unix-Style Glob Expressions. [ie: v1,v2]"
+          displayName: Unity Io Ports
+          path: config.envVars.X_CSI_BACKEND_CONFIG.unity_io_ports__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:UnityOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:Unity'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "To Remove The Host From Unity When The Last Lun Is Detached From It. By Default, It Is False."
+          displayName: Remove Empty Host
+          path: config.envVars.X_CSI_BACKEND_CONFIG.remove_empty_host
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:UnityOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:Unity'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "A Comma-Separated List Of Storage Pool Names To Be Used. [ie: v1,v2]"
+          displayName: Unity Storage Pool Names
+          path: config.envVars.X_CSI_BACKEND_CONFIG.unity_storage_pool_names__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:UnityOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:Unity'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Default Adapter Type To Be Used For Attaching Volumes."
+          displayName: Vmware Adapter Type
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_adapter_type
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVStorageObjectOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:lsiLogic'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:busLogic'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:lsiLogicsas'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:paraVirtual'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:ide'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVStorageObject'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Volume Snapshot Format In Vcenter Server."
+          displayName: Vmware Snapshot Format
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_snapshot_format
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVStorageObjectOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:template'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:COW'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVStorageObject'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Number Of Times Vmware Vcenter Server Api Must Be Retried Upon Connection Related Issues."
+          displayName: Vmware Api Retry Count
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_api_retry_count
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVStorageObjectOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVStorageObject'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Ip Address For Connecting To Vmware Vcenter Server."
+          displayName: Vmware Host Ip
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_host_ip
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVStorageObjectOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVStorageObject'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Password For Authenticating With Vmware Vcenter Server."
+          displayName: Vmware Host Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_host_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVStorageObjectOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVStorageObject'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Name Of The Vcenter Inventory Folder That Will Contain Cinder Volumes. This Folder Will Be Created Under 'Openstack/<Project_Folder>', Where Project_Folder Is Of Format 'Project (<Volume_Project_Id>)'."
+          displayName: Vmware Volume Folder
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_volume_folder
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVStorageObjectOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVStorageObject'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Port Number For Connecting To Vmware Vcenter Server. (min=0, max=65535)"
+          displayName: Vmware Host Port
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_host_port
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVStorageObjectOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVStorageObject'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Timeout In Seconds For Vmdk Volume Transfer Between Cinder And Glance."
+          displayName: Vmware Image Transfer Timeout Secs
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_image_transfer_timeout_secs
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVStorageObjectOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVStorageObject'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Optional String Specifying The Vmware Vcenter Server Version. The Driver Attempts To Retrieve The Version From Vmware Vcenter Server. Set This Configuration Only If You Want To Override The Vcenter Server Version."
+          displayName: Vmware Host Version
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_host_version
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVStorageObjectOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVStorageObject'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Interval (In Seconds) For Polling Remote Tasks Invoked On Vmware Vcenter Server."
+          displayName: Vmware Task Poll Interval
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_task_poll_interval
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVStorageObjectOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVStorageObject'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "If True, The Backend Volume In Vcenter Server Is Created Lazily When The Volume Is Created Without Any Source. The Backend Volume Is Created When The Volume Is Attached, Uploaded To Image Service Or During Backup."
+          displayName: Vmware Lazy Create
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_lazy_create
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVStorageObjectOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVStorageObject'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Max Number Of Objects To Be Retrieved Per Batch. Query Results Will Be Obtained In Batches From The Server And Not In One Shot. Server May Still Limit The Count To Something Less Than The Configured Value."
+          displayName: Vmware Max Objects Retrieval
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_max_objects_retrieval
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVStorageObjectOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVStorageObject'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "If True, The Vcenter Server Certificate Is Not Verified. If False, Then The Default Ca Truststore Is Used For Verification. This Option Is Ignored If 'Vmware_Ca_File' Is Set."
+          displayName: Vmware Insecure
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_insecure
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVStorageObjectOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVStorageObject'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Optional Vim Service Wsdl Location E.G Http://<Server>/Vimservice.Wsdl. Optional Over-Ride To Default Location For Bug Work-Arounds."
+          displayName: Vmware Wsdl Location
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_wsdl_location
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVStorageObjectOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVStorageObject'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Ca Bundle File To Use In Verifying The Vcenter Server Certificate."
+          displayName: Vmware Ca File
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_ca_file
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVStorageObjectOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVStorageObject'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Regular Expression Pattern To Match The Name Of Datastores Where Backend Volumes Are Created."
+          displayName: Vmware Datastore Regex
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_datastore_regex
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVStorageObjectOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVStorageObject'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Name Of A Vcenter Compute Cluster Where Volumes Should Be Created."
+          displayName: Vmware Cluster Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_cluster_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVStorageObjectOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVStorageObject'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Directory Where Virtual Disks Are Stored During Volume Backup And Restore."
+          displayName: Vmware Tmp Dir
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_tmp_dir
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVStorageObjectOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVStorageObject'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Username For Authenticating With Vmware Vcenter Server."
+          displayName: Vmware Host Username
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_host_username
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVStorageObjectOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVStorageObject'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Maximum Number Of Connections In Http Connection Pool."
+          displayName: Vmware Connection Pool Size
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_connection_pool_size
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVStorageObjectOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVStorageObject'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Default Adapter Type To Be Used For Attaching Volumes."
+          displayName: Vmware Adapter Type
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_adapter_type
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVcVmdkOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:lsiLogic'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:busLogic'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:lsiLogicsas'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:paraVirtual'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:ide'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVcVmdk'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Volume Snapshot Format In Vcenter Server."
+          displayName: Vmware Snapshot Format
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_snapshot_format
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVcVmdkOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:template'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:COW'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVcVmdk'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Number Of Times Vmware Vcenter Server Api Must Be Retried Upon Connection Related Issues."
+          displayName: Vmware Api Retry Count
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_api_retry_count
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVcVmdkOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVcVmdk'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Ip Address For Connecting To Vmware Vcenter Server."
+          displayName: Vmware Host Ip
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_host_ip
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVcVmdkOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVcVmdk'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Password For Authenticating With Vmware Vcenter Server."
+          displayName: Vmware Host Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_host_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVcVmdkOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVcVmdk'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Name Of The Vcenter Inventory Folder That Will Contain Cinder Volumes. This Folder Will Be Created Under 'Openstack/<Project_Folder>', Where Project_Folder Is Of Format 'Project (<Volume_Project_Id>)'."
+          displayName: Vmware Volume Folder
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_volume_folder
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVcVmdkOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVcVmdk'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Port Number For Connecting To Vmware Vcenter Server. (min=0, max=65535)"
+          displayName: Vmware Host Port
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_host_port
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVcVmdkOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVcVmdk'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Timeout In Seconds For Vmdk Volume Transfer Between Cinder And Glance."
+          displayName: Vmware Image Transfer Timeout Secs
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_image_transfer_timeout_secs
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVcVmdkOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVcVmdk'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Optional String Specifying The Vmware Vcenter Server Version. The Driver Attempts To Retrieve The Version From Vmware Vcenter Server. Set This Configuration Only If You Want To Override The Vcenter Server Version."
+          displayName: Vmware Host Version
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_host_version
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVcVmdkOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVcVmdk'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "The Interval (In Seconds) For Polling Remote Tasks Invoked On Vmware Vcenter Server."
+          displayName: Vmware Task Poll Interval
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_task_poll_interval
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVcVmdkOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVcVmdk'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "If True, The Backend Volume In Vcenter Server Is Created Lazily When The Volume Is Created Without Any Source. The Backend Volume Is Created When The Volume Is Attached, Uploaded To Image Service Or During Backup."
+          displayName: Vmware Lazy Create
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_lazy_create
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVcVmdkOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVcVmdk'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Max Number Of Objects To Be Retrieved Per Batch. Query Results Will Be Obtained In Batches From The Server And Not In One Shot. Server May Still Limit The Count To Something Less Than The Configured Value."
+          displayName: Vmware Max Objects Retrieval
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_max_objects_retrieval
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVcVmdkOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVcVmdk'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "If True, The Vcenter Server Certificate Is Not Verified. If False, Then The Default Ca Truststore Is Used For Verification. This Option Is Ignored If 'Vmware_Ca_File' Is Set."
+          displayName: Vmware Insecure
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_insecure
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVcVmdkOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVcVmdk'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Optional Vim Service Wsdl Location E.G Http://<Server>/Vimservice.Wsdl. Optional Over-Ride To Default Location For Bug Work-Arounds."
+          displayName: Vmware Wsdl Location
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_wsdl_location
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVcVmdkOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVcVmdk'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Ca Bundle File To Use In Verifying The Vcenter Server Certificate."
+          displayName: Vmware Ca File
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_ca_file
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVcVmdkOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVcVmdk'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Regular Expression Pattern To Match The Name Of Datastores Where Backend Volumes Are Created."
+          displayName: Vmware Datastore Regex
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_datastore_regex
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVcVmdkOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVcVmdk'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Name Of A Vcenter Compute Cluster Where Volumes Should Be Created."
+          displayName: Vmware Cluster Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_cluster_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVcVmdkOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVcVmdk'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Directory Where Virtual Disks Are Stored During Volume Backup And Restore."
+          displayName: Vmware Tmp Dir
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_tmp_dir
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVcVmdkOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVcVmdk'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Username For Authenticating With Vmware Vcenter Server."
+          displayName: Vmware Host Username
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_host_username
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVcVmdkOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVcVmdk'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Maximum Number Of Connections In Http Connection Pool."
+          displayName: Vmware Connection Pool Size
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vmware_connection_pool_size
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VMwareVcVmdkOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VMwareVcVmdk'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Comma-Separated List Of Storage Pool Names To Be Used. [ie: v1,v2]"
+          displayName: Storage Vnx Pool Names
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storage_vnx_pool_names__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VNXOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VNX'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "To Destroy Storage Group When The Last Lun Is Removed From It. By Default, The Value Is False."
+          displayName: Destroy Empty Storage Group
+          path: config.envVars.X_CSI_BACKEND_CONFIG.destroy_empty_storage_group
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VNXOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VNX'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Vnx Authentication Scope Type. By Default, The Value Is Global."
+          displayName: Storage Vnx Authentication Type
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storage_vnx_authentication_type
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VNXOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VNX'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Default Timeout For Cli Operations In Minutes. For Example, Lun Migration Is A Typical Long Running Operation, Which Depends On The Lun Size And The Load Of The Array. An Upper Bound In The Specific Deployment Can Be Set To Avoid Unnecessary Long Wait. By Default, It Is 365 Days Long."
+          displayName: Default Timeout
+          path: config.envVars.X_CSI_BACKEND_CONFIG.default_timeout
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VNXOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VNX'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Automatically Deregister Initiators After The Related Storage Group Is Destroyed. By Default, The Value Is False."
+          displayName: Initiator Auto Deregistration
+          path: config.envVars.X_CSI_BACKEND_CONFIG.initiator_auto_deregistration
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VNXOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VNX'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Always Use Asynchronous Migration During Volume Cloning And Creating From Snapshot. As Described In Configuration Doc, Async Migration Has Some Constraints. Besides Using Metadata, Customers Could Use This Option To Disable Async Migration. Be Aware That `Async_Migrate` In Metadata Overrides This Option When Both Are Set. By Default, The Value Is True."
+          displayName: Vnx Async Migrate
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vnx_async_migrate
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VNXOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VNX'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Delete A Lun Even If It Is In Storage Groups."
+          displayName: Force Delete Lun In Storagegroup
+          path: config.envVars.X_CSI_BACKEND_CONFIG.force_delete_lun_in_storagegroup
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VNXOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VNX'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Naviseccli Path."
+          displayName: Naviseccli Path
+          path: config.envVars.X_CSI_BACKEND_CONFIG.naviseccli_path
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VNXOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VNX'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Comma Separated Iscsi Or Fc Ports To Be Used In Nova Or Cinder. [ie: v1,v2]"
+          displayName: Io Port List
+          path: config.envVars.X_CSI_BACKEND_CONFIG.io_port_list__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VNXOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VNX'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Directory Path That Contains The Vnx Security File. Make Sure The Security File Is Generated First."
+          displayName: Storage Vnx Security File Dir
+          path: config.envVars.X_CSI_BACKEND_CONFIG.storage_vnx_security_file_dir
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VNXOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VNX'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Automatically Register Initiators. By Default, The Value Is False."
+          displayName: Initiator Auto Registration
+          path: config.envVars.X_CSI_BACKEND_CONFIG.initiator_auto_registration
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VNXOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VNX'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Mapping Between Hostname And Its Iscsi Initiator Ip Addresses."
+          displayName: Iscsi Initiators
+          path: config.envVars.X_CSI_BACKEND_CONFIG.iscsi_initiators
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VNXOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VNX'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Force Lun Creation Even If The Full Threshold Of Pool Is Reached. By Default, The Value Is False."
+          displayName: Ignore Pool Full Threshold
+          path: config.envVars.X_CSI_BACKEND_CONFIG.ignore_pool_full_threshold
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VNXOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VNX'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Default Max Number Of Luns In A Storage Group. By Default, The Value Is 255."
+          displayName: Max Luns Per Storage Group
+          path: config.envVars.X_CSI_BACKEND_CONFIG.max_luns_per_storage_group
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VNXOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VNX'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Percent Of Actual Usage Of The Underlying Volume Before No New Volumes Can Be Allocated To The Volume Destination."
+          displayName: Vzstorage Used Ratio
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vzstorage_used_ratio
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VZStorageOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VZStorage'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "File With The List Of Available Vzstorage Shares."
+          displayName: Vzstorage Shares Config
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vzstorage_shares_config
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VZStorageOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VZStorage'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Base Dir Containing Mount Points For Vzstorage Shares."
+          displayName: Vzstorage Mount Point Base
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vzstorage_mount_point_base
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VZStorageOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VZStorage'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Create Volumes As Sparsed Files Which Take No Space Rather Than Regular Files When Using Raw Format, In Which Case Volume Creation Takes Lot Of Time."
+          displayName: Vzstorage Sparsed Volumes
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vzstorage_sparsed_volumes
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VZStorageOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VZStorage'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Mount Options Passed To The Vzstorage Client. See Section Of The Pstorage-Mount Man Page For Details. [ie: v1,v2]"
+          displayName: Vzstorage Mount Options
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vzstorage_mount_options__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VZStorageOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VZStorage'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Default Format That Will Be Used When Creating Volumes If No Volume Format Is Specified."
+          displayName: Vzstorage Default Volume Format
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vzstorage_default_volume_format
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VZStorageOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VZStorage'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Allow Volumes To Be Created In Storage Pools When Zero Padding Is Disabled. This Option Should Not Be Enabled If Multiple Tenants Will Utilize Volumes From A Shared Storage Pool."
+          displayName: Vxflexos Allow Non Padded Volumes
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vxflexos_allow_non_padded_volumes
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VxFlexOSOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VxFlexOS'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Vxflex Os/Scaleio Api Version. This Value Should Be Left As The Default Value Unless Otherwise Instructed By Technical Support."
+          displayName: Vxflexos Server Api Version
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vxflexos_server_api_version
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VxFlexOSOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VxFlexOS'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Gateway Rest Server Port. (min=0, max=65535)"
+          displayName: Vxflexos Rest Server Port
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vxflexos_rest_server_port
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VxFlexOSOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VxFlexOS'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Unmap Volumes Before Deletion."
+          displayName: Vxflexos Unmap Volume Before Deletion
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vxflexos_unmap_volume_before_deletion
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VxFlexOSOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VxFlexOS'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Round Volume Sizes Up To 8Gb Boundaries. Vxflex Os/Scaleio Requires Volumes To Be Sized In Multiples Of 8Gb. If Set To False, Volume Creation Will Fail For Volumes Not Sized Properly"
+          displayName: Vxflexos Round Volume Capacity
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vxflexos_round_volume_capacity
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VxFlexOSOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VxFlexOS'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Storage Pools. Comma Separated List Of Storage Pools Used To Provide Volumes. Each Pool Should Be Specified As A Protection_Domain_Name:Storage_Pool_Name Value"
+          displayName: Vxflexos Storage Pools
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vxflexos_storage_pools
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VxFlexOSOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VxFlexOS'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Max_Over_Subscription_Ratio Setting For The Driver. Maximum Value Allowed Is 10.0."
+          displayName: Vxflexos Max Over Subscription Ratio
+          path: config.envVars.X_CSI_BACKEND_CONFIG.vxflexos_max_over_subscription_ratio
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:VxFlexOSOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:VxFlexOS'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Path To Store Vhd Backed Volumes"
+          displayName: Windows Iscsi Lun Path
+          path: config.envVars.X_CSI_BACKEND_CONFIG.windows_iscsi_lun_path
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:WindowsISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:WindowsISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Mappings Between Share Locations And Pool Names. If Not Specified, The Share Names Will Be Used As Pool Names. Example: //Addr/Share:Pool_Name,//Addr/Share2:Pool_Name2 [ie: k1:v1,k2:v2]"
+          displayName: Smbfs Pool Mappings
+          path: config.envVars.X_CSI_BACKEND_CONFIG.smbfs_pool_mappings__transform_csv_kvs
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:WindowsSmbfsOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:WindowsSmbfs'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "File With The List Of Available Smbfs Shares."
+          displayName: Smbfs Shares Config
+          path: config.envVars.X_CSI_BACKEND_CONFIG.smbfs_shares_config
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:WindowsSmbfsOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:WindowsSmbfs'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Base Dir Containing Mount Points For Smbfs Shares."
+          displayName: Smbfs Mount Point Base
+          path: config.envVars.X_CSI_BACKEND_CONFIG.smbfs_mount_point_base
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:WindowsSmbfsOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:WindowsSmbfs'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Default Format That Will Be Used When Creating Volumes If No Volume Format Is Specified."
+          displayName: Smbfs Default Volume Format
+          path: config.envVars.X_CSI_BACKEND_CONFIG.smbfs_default_volume_format
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:WindowsSmbfsOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:vhd'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:vhdx'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:WindowsSmbfs'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Number Of Retries In Case Array Is Busy"
+          displayName: Xtremio Array Busy Retry Count
+          path: config.envVars.X_CSI_BACKEND_CONFIG.xtremio_array_busy_retry_count
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:XtremIOFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:XtremIOFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Password For San Controller"
+          displayName: San Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:XtremIOFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:XtremIOFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "If Set To True The Http Client Will Validate The Ssl Certificate Of The Backend Endpoint."
+          displayName: Driver Ssl Cert Verify
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver_ssl_cert_verify
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:XtremIOFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:XtremIOFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Username For San Controller"
+          displayName: San Login
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_login
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:XtremIOFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:XtremIOFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Xms Cluster Id In Multi-Cluster Environment"
+          displayName: Xtremio Cluster Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.xtremio_cluster_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:XtremIOFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:XtremIOFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Can Be Used To Specify A Non Default Path To A Ca_Bundle File Or Directory With Certificates Of Trusted Cas, Which Will Be Used To Validate The Backend"
+          displayName: Driver Ssl Cert Path
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver_ssl_cert_path
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:XtremIOFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:XtremIOFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Should The Driver Remove Initiator Groups With No Volumes After The Last Connection Was Terminated. Since The Behavior Till Now Was To Leave The Ig Be, We Default To False (Not Deleting Igs Without Connected Volumes); Setting This Parameter To True Will Remove Any Ig After Terminating Its Connection To The Last Volume."
+          displayName: Xtremio Clean Unused Ig
+          path: config.envVars.X_CSI_BACKEND_CONFIG.xtremio_clean_unused_ig
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:XtremIOFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:XtremIOFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Interval Between Retries In Case Array Is Busy"
+          displayName: Xtremio Array Busy Retry Interval
+          path: config.envVars.X_CSI_BACKEND_CONFIG.xtremio_array_busy_retry_interval
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:XtremIOFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:XtremIOFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Ip Address Of San Controller"
+          displayName: San Ip
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_ip
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:XtremIOFCOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:XtremIOFC'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Number Of Retries In Case Array Is Busy"
+          displayName: Xtremio Array Busy Retry Count
+          path: config.envVars.X_CSI_BACKEND_CONFIG.xtremio_array_busy_retry_count
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:XtremIOISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:XtremIOISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Password For San Controller"
+          displayName: San Password
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_password
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:XtremIOISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:XtremIOISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "If Set To True The Http Client Will Validate The Ssl Certificate Of The Backend Endpoint."
+          displayName: Driver Ssl Cert Verify
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver_ssl_cert_verify
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:XtremIOISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:XtremIOISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Username For San Controller"
+          displayName: San Login
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_login
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:XtremIOISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:XtremIOISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Xms Cluster Id In Multi-Cluster Environment"
+          displayName: Xtremio Cluster Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.xtremio_cluster_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:XtremIOISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:XtremIOISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Can Be Used To Specify A Non Default Path To A Ca_Bundle File Or Directory With Certificates Of Trusted Cas, Which Will Be Used To Validate The Backend"
+          displayName: Driver Ssl Cert Path
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver_ssl_cert_path
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:XtremIOISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:XtremIOISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Should The Driver Remove Initiator Groups With No Volumes After The Last Connection Was Terminated. Since The Behavior Till Now Was To Leave The Ig Be, We Default To False (Not Deleting Igs Without Connected Volumes); Setting This Parameter To True Will Remove Any Ig After Terminating Its Connection To The Last Volume."
+          displayName: Xtremio Clean Unused Ig
+          path: config.envVars.X_CSI_BACKEND_CONFIG.xtremio_clean_unused_ig
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:XtremIOISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:XtremIOISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Interval Between Retries In Case Array Is Busy"
+          displayName: Xtremio Array Busy Retry Interval
+          path: config.envVars.X_CSI_BACKEND_CONFIG.xtremio_array_busy_retry_interval
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:XtremIOISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:XtremIOISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Ip Address Of San Controller"
+          displayName: San Ip
+          path: config.envVars.X_CSI_BACKEND_CONFIG.san_ip
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:XtremIOISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:XtremIOISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Vpsa - Default Encryption Policy For Volumes"
+          displayName: Zadara Vol Encrypt
+          path: config.envVars.X_CSI_BACKEND_CONFIG.zadara_vol_encrypt
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:ZadaraVPSAISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:ZadaraVPSAISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Vpsa - Use Iser Instead Of Iscsi"
+          displayName: Zadara Use Iser
+          path: config.envVars.X_CSI_BACKEND_CONFIG.zadara_use_iser
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:ZadaraVPSAISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:ZadaraVPSAISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Vpsa - Attach Snapshot Policy For Volumes"
+          displayName: Zadara Default Snap Policy
+          path: config.envVars.X_CSI_BACKEND_CONFIG.zadara_default_snap_policy
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:ZadaraVPSAISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:ZadaraVPSAISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Vpsa - Use Ssl Connection"
+          displayName: Zadara Vpsa Use Ssl
+          path: config.envVars.X_CSI_BACKEND_CONFIG.zadara_vpsa_use_ssl
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:ZadaraVPSAISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:ZadaraVPSAISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Vpsa - Management Host Name Or Ip Address"
+          displayName: Zadara Vpsa Host
+          path: config.envVars.X_CSI_BACKEND_CONFIG.zadara_vpsa_host
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:ZadaraVPSAISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:ZadaraVPSAISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Vpsa - Storage Pool Assigned For Volumes"
+          displayName: Zadara Vpsa Poolname
+          path: config.envVars.X_CSI_BACKEND_CONFIG.zadara_vpsa_poolname
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:ZadaraVPSAISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:ZadaraVPSAISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "If Set To True The Http Client Will Validate The Ssl Certificate Of The Vpsa Endpoint."
+          displayName: Zadara Ssl Cert Verify
+          path: config.envVars.X_CSI_BACKEND_CONFIG.zadara_ssl_cert_verify
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:ZadaraVPSAISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:ZadaraVPSAISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Vpsa - Port Number (min=0, max=65535)"
+          displayName: Zadara Vpsa Port
+          path: config.envVars.X_CSI_BACKEND_CONFIG.zadara_vpsa_port
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:ZadaraVPSAISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:ZadaraVPSAISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Vpsa Access Key"
+          displayName: Zadara Access Key
+          path: config.envVars.X_CSI_BACKEND_CONFIG.zadara_access_key
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:ZadaraVPSAISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:password'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:ZadaraVPSAISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: "Vpsa - Default Template For Vpsa Volume Names"
+          displayName: Zadara Vol Name Template
+          path: config.envVars.X_CSI_BACKEND_CONFIG.zadara_vol_name_template
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:ZadaraVPSAISCSIOptions'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:config.envVars.X_CSI_BACKEND_CONFIG.driver:ZadaraVPSAISCSI'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: Backend name (set by operator if empty)
+          displayName: Name
+          path: config.envVars.X_CSI_BACKEND_CONFIG.name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: The unique name of the plugin (set by operator if empty)
+          displayName: Plugin name
+          path: config.envVars.X_CSI_EMBER_CONFIG.plugin_name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: Number of gRPC workers for the CSI plugin
+          displayName: gRPC workers
+          path: config.envVars.X_CSI_EMBER_CONFIG.grpc_workers
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:number'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: Allow keepalive pings when there are no gRPC calls
+          displayName: Slow operations
+          path: config.envVars.X_CSI_EMBER_CONFIG.slow_operations
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: Get stats from the storage backend when the CSI plugin is probed
+          displayName: Probe backend
+          path: config.envVars.X_CSI_EMBER_CONFIG.enable_probe
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: > List of features we want to disable on the plugin.
+            Features that can be disabled are clone, snapshot, expand,
+            expand_online. Must be a JSON list ie: ["clone", "expand_online"]'
+          displayName: Disabled features
+          path: config.envVars.X_CSI_EMBER_CONFIG.disabled__transform_csv
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: Project ID to store in the persistence metadata backend
+          displayName: Project ID
+          path: config.envVars.X_CSI_EMBER_CONFIG.project_id
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: User ID to store in the persistence metadata backend
+          displayName: User ID
+          path: config.envVars.X_CSI_EMBER_CONFIG.user_id
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: Disable all the logs in the CSI plugins
+          displayName: Quiet
+          path: config.envVars.X_CSI_EMBER_CONFIG.disable_logs
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: Enabled debug log levels (quiet option must not be set)
+          displayName: Debug logs
+          path: config.envVars.X_CSI_EMBER_CONFIG.debug
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        # - description: If we want to abort or queue (default) duplicated requests.
+        #   displayName: Abort duplicates
+        #   path: config.envVars.X_CSI_ABORT_DUPLICATES
+        #   x-descriptors:
+        #     - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+        #     - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        #     - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: Enable remote debugging with rpdb on calls
+          displayName: Remote debugging
+          path: config.envVars.X_CSI_DEBUG_MODE
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:RPDB'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: Default filesystem for mount type volumes when it is not specified
+          displayName: Default filesystem
+          path: config.envVars.X_CSI_DEFAULT_MOUNT_FS
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:btrfs'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:cramfs'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:ext2'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:ext3'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:ext4'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:minix'
+            - 'urn:alm:descriptor:com.tectonic.ui:select:xfs'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        # - description: Metadata persistence plugin selection and settings (must be valid JSON)
+        #   displayName: Persistence
+        #   path: config.envVars.X_CSI_PERSISTENCE_CONFIG
+        #   x-descriptors:
+        #     - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+        #     - 'urn:alm:descriptor:com.tectonic.ui:text'
+        #     - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: Allow unsupported drivers to run
+          displayName: Unsupported
+          path: config.envVars.X_CSI_BACKEND_CONFIG.enable_unsupported_driver
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: sysFiles secrets
+          displayName: sysFiles secrets
+          path: config.sysFiles.key
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:io.kubernetes:Secret'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: sysFiles secrets
+          displayName: sysFiles secrets name
+          path: config.sysFiles.name
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:AdvancedSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - description: Use multipath if driver supports it
+          displayName: Multipath
+          path: config.X_CSI_BACKEND_CONFIG.multipath
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:DriverSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:checkbox'
+        # END AUTO GENERATED CONFIGURATION OPTIONS
+


### PR DESCRIPTION
There are too many drivers to add configuration options manually, so we leverage the Ember-CSI script that outputs detailed information about drivers to automatically generate the form fields and examples on the OLM catalog.

The new script olvm-csv-gen.sh runs an Ember-CSI docker container to get the driver specific configuration options and the passes them to a Python script to generate the Cluster Service Version YAML file `deploy/olm-catalog/next/ember-csi-operator.vX.Y.Z.clusterserviceversion.yaml`

In this file we'll have:

- One example with all the configuration options for all the drivers (this is used for default values).
- One example for each driver which its own configuration options.
- The form options.

The Python script has the capability to ignore some drivers (like the NFS ones we don't support), to ignore some configuration options (which are irrelevant form Ember-CSI), and it also adds missing configuration options (Cinder drivers are not properly reporting all the configuration options that are actually using).

The form options will be generated on an independent group by default because the first console version that supports hiding fields is in OpenShift 4.4.  If we want to generate the sample file for such a console we can set env variable `CONSOLE_VERSION` to 4.4

For development we can also generate `out.yaml` using a different template (`template-dev.yaml`) setting `DEVELOPMENT` env var to a non zero int, which will allow us to copy/paste it into the console (we have to change the `resourceVersion` field with the latest one that appears on the console).

This patch also includes an example of what the generated file looks like.