### PR TITLE
UI: Add missing RBD parameter

### DIFF
--- a/build/olm-catalog/yaml-options-gen.py
+++ b/build/olm-catalog/yaml-options-gen.py
@@ -173,6 +173,16 @@ MISSING_OPTIONS = (
      "type": "Integer(min=1, max=128)"},
 )
 
+EMBER_OPTIONS = [
+    {"default": "",
+     "deprecated_for_removal": "False",
+     "help": "Path to the ceph keyring file",
+     "name": "rbd_keyring_conf",
+     "required": "False",
+     "secret": "False",
+     "type": "String"},
+]
+
 MISSING_DRIVER_OPTIONS = {
     'QnapISCSI': ('target_ip_address', 'san_login', 'san_password',
                   'use_chap_auth', 'chap_username', 'chap_password',
@@ -215,6 +225,7 @@ MISSING_DRIVER_OPTIONS = {
                'use_chap_auth'),
     'SolidFire': ('san_ip', 'san_login', 'san_password',
                   'driver_ssl_cert_verify'),
+    'RBD': ('rbd_keyring_conf',),
 }
 
 IGNORE_OPTIONS = ['max_over_subscription_ratio',
@@ -645,6 +656,11 @@ def generate_examples(original_drivers, options):
 def add_missing_config_options(backends, options):
     for option_data in MISSING_OPTIONS:
         options.setdefault(option_data['name'], Option(option_data))
+
+    # These are options that we are forcing the tool to have for Ember-CSI,
+    # even if they are deprecated or no longer exist in Cinder.
+    for option_data in EMBER_OPTIONS:
+        options[option_data['name']] = Option(option_data)
 
     for driver_name, option_names in MISSING_DRIVER_OPTIONS.items():
         if driver_name in backends:

--- a/deploy/examples/drivers/RBD.yaml
+++ b/deploy/examples/drivers/RBD.yaml
@@ -19,6 +19,7 @@ spec:
         rbd_cluster_name: ceph
         rbd_exclusive_cinder_pool: false
         rbd_flatten_volume_from_snapshot: false
+        rbd_keyring_conf: ''
         rbd_max_clone_depth: 5
         rbd_pool: rbd
         rbd_secret_uuid: ''

--- a/deploy/olm-catalog/next/ember-csi-operator.vX.Y.Z.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/next/ember-csi-operator.vX.Y.Z.clusterserviceversion.yaml
@@ -475,6 +475,7 @@ metadata:
                   "driver__RBD__rbd_cluster_name": "ceph",
                   "driver__RBD__rbd_exclusive_cinder_pool": false,
                   "driver__RBD__rbd_flatten_volume_from_snapshot": false,
+                  "driver__RBD__rbd_keyring_conf": "",
                   "driver__RBD__rbd_max_clone_depth": 5,
                   "driver__RBD__rbd_pool": "rbd",
                   "driver__RBD__rbd_secret_uuid": "",
@@ -4149,6 +4150,13 @@ spec:
         - description: "Path To The Ceph Configuration File"
           displayName: Rbd Ceph Conf
           path: config.envVars.X_CSI_BACKEND_CONFIG.driver__RBD__rbd_ceph_conf
+          x-descriptors:
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:DriverSettings'
+            - 'urn:alm:descriptor:com.tectonic.ui:text'
+            - 'urn:alm:descriptor:com.tectonic.ui:fieldDependency:spec.config.envVars.X_CSI_BACKEND_CONFIG.driver:RBD'
+        - description: "Path To The Ceph Keyring File"
+          displayName: Rbd Keyring Conf
+          path: config.envVars.X_CSI_BACKEND_CONFIG.driver__RBD__rbd_keyring_conf
           x-descriptors:
             - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:DriverSettings'
             - 'urn:alm:descriptor:com.tectonic.ui:text'


### PR DESCRIPTION
The rbd_keyring_conf parameter has been marked as deprecated in Cinder
because it should not be used within OpenStack, as users there can see
the connection information and would then gain access to the whole
cluster.

But in Ember-CSI is completely different, because here normal users
should not have access to the Ember-CSI CRD objects where this
information is kept.

Since we are removing deprecated options by default this option was
removed from the form and examples, so in this patch we forcefully add
it in the generator.