### PR TITLE
Fix transform_csv on empty strings

### DIFF
--- a/pkg/controller/embercsi/common.go
+++ b/pkg/controller/embercsi/common.go
@@ -575,7 +575,11 @@ func configTransform(input string) string {
 
 		if strings.HasSuffix(k, "__transform_csv") {
 			newkey := strings.Replace(k, "__transform_csv", "", -1)
-			m[newkey] = strings.Split(v.(string), ",")
+			if len(v.(string)) > 0 {
+				m[newkey] = strings.Split(v.(string), ",")
+			} else {
+				m[newkey] = []string{}
+			}
 			delete(m, k)
 		}
 

--- a/pkg/controller/embercsi/common_test.go
+++ b/pkg/controller/embercsi/common_test.go
@@ -87,6 +87,14 @@ func TestConfigTransform(t *testing.T) {
 		t.Errorf("Failed to transform, got %v, expected %v\n", result, expected)
 	}
 
+        input = "{\"key__transform_csv\":\"\"}"
+        expected = "{\"key\":[]}"
+        result = configTransform(input)
+        if result != expected {
+                t.Errorf("Failed to transform, got %v, expected %v\n", result, expected)
+        }
+
+
 	input = "{\"key__transform_csv_kvs\":\"a:b\"}"
 	expected = "{\"key\":{\"a\":\"b\"}}"
 	result = configTransform(input)


### PR DESCRIPTION
Make sure an empty string is transformed into an empty list,
not a list with a single 0-byte sized string.