### PR TITLE
Tweak the old-csv-gen.sh script

### DIFF
--- a/build/olm-catalog/olm-csv-gen.sh
+++ b/build/olm-catalog/olm-csv-gen.sh
@@ -10,7 +10,7 @@ else
   dest_file=./out.yaml
 fi
 
-podman pull embercsi/ember-csi:$TAG
+podman pull quay.io/embercsi/ember-csi:$TAG
 
 echo "Getting driver config from tag $TAG and writing result to $dest_file"
-docker run --rm embercsi/ember-csi:$TAG ember-list-drivers -d | python ./yaml-options-gen.py > $dest_file
+podman run --rm quay.io/embercsi/ember-csi:$TAG ember-list-drivers -d | python ./yaml-options-gen.py > $dest_file

--- a/build/olm-catalog/yaml-options-gen.py
+++ b/build/olm-catalog/yaml-options-gen.py
@@ -223,11 +223,13 @@ MISSING_DRIVER_OPTIONS = {
 
 IGNORE_OPTIONS = ['max_over_subscription_ratio',
                   'reserved_percentage',
-                  'use_multipath_for_image_xfer',
+                  'use_multipath_for_image_xfer',  # Use global option instead
+                  'enforce_multipath_for_image_xfer',  # Not avilable for now
                   'xtremio_volumes_per_glance_cache',
                   'auto_calc_max_oversubscription_ratio',
                   'replication_device',
                   'replication_connect_timeout',
+                  'enable_unsupported_driver',  # Use global option instead
                   ]
 
 CONSOLE_VERSION = os.environ.get('CONSOLE_VERSION', '').strip() or '4.0'


### PR DESCRIPTION
This PR updates our form auto-generating script to:

- Specifically pull the ember-csi image from quay.io
- Only use `podman`
- Disable `enforce_multipath_for_image_xfer` config option
- Remove driver specific `enable_unsupported_driver` option that gets overwritten with the global one.