### PR TITLE
Remove backend config env from nodes

### DIFF
--- a/pkg/controller/embercsi/node.go
+++ b/pkg/controller/embercsi/node.go
@@ -145,13 +145,6 @@ func getNodeContainers(ecsi *embercsiv1alpha1.EmberStorageBackend, daemonSetInde
 			Env:          generateNodeEnvVars(ecsi, daemonSetIndex),
 			VolumeMounts: generateVolumeMounts(ecsi, "node"),
 			//LivenessProbe:		livenessProbe,
-			EnvFrom: []corev1.EnvFromSource{{
-				SecretRef: &corev1.SecretEnvSource{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: fmt.Sprintf("ember-csi-operator-%s", ecsi.Name),
-                                        },
-                                },
-			}},
 		},
 	}
 


### PR DESCRIPTION
Removes the secret (which includes X_CSI_BACKEND_CONFIG)
from the node environment.